### PR TITLE
Restrict SystemInfoObserver init to singleton-only access

### DIFF
--- a/Sources/SystemInfoKit/SystemInfoObserver.swift
+++ b/Sources/SystemInfoKit/SystemInfoObserver.swift
@@ -31,7 +31,7 @@ public final class SystemInfoObserver: Sendable {
         self.continuation = continuation
     }
 
-    public convenience init() {
+    convenience init() {
         self.init(dependencies: .init(), language: .automatic)
     }
 


### PR DESCRIPTION
The public convenience init() took no arguments and offered no customization beyond what `shared` already provides, so external callers could only ever build duplicates of the singleton — each spinning up its own monitoring task. Drop `public` from the convenience init so the only externally usable entry point is `SystemInfoObserver.shared`.