### PR TITLE
Add CLAUDE.md and an add-language Claude Skill

### DIFF
--- a/.claude/skills/add-language/SKILL.md
+++ b/.claude/skills/add-language/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: add-language
+description: Add a new language to SystemInfoKit. Use when the user asks to add localization for a language ("Italian に対応させたい", "add Portuguese", "support Thai localization", "新規言語追加", "add locale"). Codifies the exact 5-file recipe — Language.swift enum + Localizable.xcstrings + ByteDataTests + PercentageTests + README — with translation generation, locale-identifier verification, and a build+test verification pass.
+---
+
+# Add a new language to SystemInfoKit
+
+This skill codifies every step required to add a new language to SystemInfoKit. It exists because the recipe touches 5 files in 3 directories with no CI to catch omissions — a missed key in `.xcstrings` silently falls back to English at runtime.
+
+Only these files change:
+
+1. `Sources/SystemInfoKit/Entities/Language.swift`
+2. `Sources/SystemInfoKit/Resources/Localizable.xcstrings`
+3. `Tests/SystemInfoKitTests/EntityTests/ByteDataTests.swift`
+4. `Tests/SystemInfoKitTests/EntityTests/PercentageTests.swift`
+5. `README.md`
+
+**Do not** edit `Package.swift`, any `Repository`, any `*Info`, `SystemInfoObserver.swift`, or `Localizable.swift`.
+
+---
+
+## Step 0 — Gather 4 required inputs
+
+Ask the user (or infer from their message and confirm) these four values before touching any file:
+
+| Variable | Example | Notes |
+|----------|---------|-------|
+| Language name (English, capitalized) | `Italian` | Used in README's "Supported languages" list |
+| Enum case name | `italian` | lowerCamelCase; must sort alphabetically among existing cases (`chineseSimplified` / `chineseTraditional` / `english` / `french` / `german` / `japanese` / `korean` / `russian` / `spanish` / `vietnamese`) |
+| `Locale` initializer | `Locale(languageCode: .italian)` | Pick one form:<br>• `Locale(languageCode: .xxx)` — most languages<br>• `Locale(languageCode: .chinese, script: .hanSimplified)` — scripts<br>• `Locale(languageCode: .portuguese, script: nil, languageRegion: .brazil)` — regional variants |
+| Locale identifier | `it` | The **runtime value** of `<the Locale>.identifier`. Xcstrings uses this string as the block key, and SPM emits the compiled `.lproj` folder with this name. Verify it against Step 1's `Locale`. |
+
+**Pitfall — identifier verification is not optional.** If the identifier does not match what `Locale(...).identifier` actually returns, the `.xcstrings` translations will be compiled into the wrong `.lproj` and never surface at runtime. Verify with the one-liner in Step 6's Verification section before proceeding to Step 2.
+
+Existing coverage — do not duplicate:
+
+- Language cases: chineseSimplified, chineseTraditional, english, french, german, japanese, korean, russian, spanish, vietnamese.
+- Xcstrings locales: `de`, `en`, `es`, `fr`, `ja`, `ko`, `ru`, `vi`, `zh-Hans`, `zh-Hant`.
+
+---
+
+## Step 1 — Edit `Sources/SystemInfoKit/Entities/Language.swift`
+
+Two edits, both in the same `enum Language`:
+
+**1a. Add the case** in the `enum` body (lines 3–15), preserving alphabetical order. For a new `.italian`, it goes between `.german` and `.japanese`:
+
+```swift
+case german
+case italian    // ← new
+case japanese
+```
+
+**1b. Add the `switch` arm** in the `var locale: Locale` block (lines 16–41), same alphabetical position:
+
+```swift
+case .german:
+    Locale(languageCode: .german)
+case .italian:
+    Locale(languageCode: .italian)   // ← new; use the exact initializer from Step 0
+case .japanese:
+    Locale(languageCode: .japanese)
+```
+
+**Do not** modify `var bundle: Bundle?` (lines 43–49) — its `Bundle.module.path(forResource: locale.identifier, ofType: "lproj")` lookup is generic.
+
+---
+
+## Step 2 — Edit `Sources/SystemInfoKit/Resources/Localizable.xcstrings`
+
+For every one of the 25 keys, add a new localization block keyed by the identifier from Step 0. The reference table for all keys lives in `references/keys.md` — load it before generating translations.
+
+Block shape (add alongside the existing `de` / `en` / … blocks; xcstrings does not require alphabetical ordering of locales, but match the existing style):
+
+```json
+"<locale-id>" : {
+  "stringUnit" : {
+    "state" : "translated",
+    "value" : "<translated text>"
+  }
+}
+```
+
+Rules:
+
+- **All 25 keys must be filled.** Missing keys fall back to English silently.
+- **`state` must be `"translated"`.** Not `"new"`, not `"needs_review"` — Xcode's String Catalog editor uses these, but the runtime only cares that the value exists; the state field is preserved so tools like the Xcode editor treat the entry as complete.
+- **Preserve every format specifier.** `%@` and `%lld` must appear in every translated value that had them in the English source. Only their position may move if grammar requires.
+- **Follow typographic conventions of the target language** — see `references/keys.md` "Translation policy" section for the observed per-language conventions (fr uses ` : `, ja uses `：`, most others `: `).
+
+Generate translations in this order:
+
+1. Read `references/keys.md` for the 25 key list and format constraints.
+2. Read a few existing entries from a linguistically similar language (e.g. for Italian, look at the existing `fr` and `es` blocks) to match the punctuation convention.
+3. Produce all 25 translations at once in a single message, formatted as `key → value` pairs, and ask the user to confirm before writing the file.
+4. Only after confirmation, edit the xcstrings file.
+
+Editing approach for the xcstrings file: prefer `Edit` (or many small `Edit` calls) over `Write` — the file is large JSON and a full rewrite risks reordering or reformatting existing entries.
+
+---
+
+## Step 3 — Edit `Tests/SystemInfoKitTests/EntityTests/ByteDataTests.swift`
+
+Add one new element to the `@Test(arguments: [...])` array (lines 7–68), in alphabetical position by enum case name.
+
+Field values are deterministic:
+
+- `language`: the new enum case.
+- `expectedValue`: **always `888.889`** — the numeric readable value produced by `MeasurementFormatter` for `888_888_888_888` bytes is the same across every existing locale, and the parse-back uses `numberStyle = .decimal` so locale decimal separators are handled by the formatter.
+- `expectedUnit`: what `MeasurementFormatter(unitStyle:.short, unitOptions:.naturalScale)` produces for the locale on that byte count. Most languages emit `"GB"`. Known exceptions: `fr` → `"Go"`, `ru` → `"ГБ"`. **Verify** with the one-liner in Verification.
+- `expectedDescription`: `"888.9 <unit>"` (period) or `"888,9 <unit>"` (comma) depending on the locale's decimal separator. Formed by `Percentage`-style formatting through the same locale — verify with the same one-liner.
+
+Example new row for Italian (comma-decimal, `GB`):
+
+```swift
+.init(
+    language: .italian,
+    expectedValue: 888.889,
+    expectedUnit: "GB",
+    expectedDescription: "888,9 GB"
+),
+```
+
+---
+
+## Step 4 — Edit `Tests/SystemInfoKitTests/EntityTests/PercentageTests.swift`
+
+Add one new element to the `@Test(arguments: [...])` array (lines 7–17), alphabetical position:
+
+```swift
+.init(language: .italian, expectedDescription: "88,9%"),
+```
+
+Decimal separator judgment (empirically confirmed for existing locales):
+
+- Uses `.`: `en`, `ja`, `ko`, `zh-Hans`, `zh-Hant`.
+- Uses `,`: `de`, `es`, `fr`, `ru`, `vi`.
+
+For a new locale, verify with the one-liner in Verification — the CLDR data behind `Locale` occasionally surprises.
+
+---
+
+## Step 5 — Edit `README.md`
+
+Add the language name (English, capitalized) to the bulleted "Supported languages" list (currently lines 119–130), in alphabetical position:
+
+```markdown
+- German
+- Italian    ← new
+- Japanese
+```
+
+---
+
+## Step 6 — Verification
+
+Run all four checks. Do not declare done until all pass.
+
+### 6a. Confirm `Locale.identifier`, `MeasurementFormatter` output, decimal separator
+
+Write and run this scratch program to lock down the values used in Steps 3 and 4. **Adapt the `Locale(...)` line to whatever Step 0 chose.**
+
+```swift
+// scratchpad/verify-locale.swift
+import Foundation
+
+let locale = Locale(languageCode: .italian)  // ← match Step 0
+print("identifier:", locale.identifier)      // must equal the Step 0 identifier
+
+let mf = MeasurementFormatter()
+mf.locale = locale
+mf.unitStyle = .short
+mf.unitOptions = .naturalScale
+let m = Measurement(value: 888_888_888_888, unit: UnitInformationStorage.bytes)
+print("bytes readable:", mf.string(from: m)) // → expectedUnit + expectedDescription
+
+let pct = String(format: "%.1f", locale: locale, 88.9)
+print("percent format:", pct)                // "88.9" → '.'; "88,9" → ','
+```
+
+Run:
+
+```bash
+swift /path/to/verify-locale.swift
+```
+
+If `identifier:` does not match Step 0's identifier, fix Step 0 before proceeding — the xcstrings block will otherwise land under the wrong key.
+
+### 6b. Build
+
+```bash
+swift build
+```
+
+Must succeed with no warnings introduced by the diff.
+
+### 6c. Test the affected suites first, then the full suite
+
+```bash
+swift test --filter ByteDataTests
+swift test --filter PercentageTests
+swift test
+```
+
+If the two filtered runs fail, cross-check the actual `MeasurementFormatter` / `%.1f` output against your Step 6a scratch output — those are the truth.
+
+### 6d. Repository tests (regression)
+
+Repository tests (`BatteryRepositoryTests` etc.) hard-code English string expectations. They should stay green — if any fail, you inadvertently edited an English translation in `.xcstrings`. Revert that change.
+
+---
+
+## Non-goals — do NOT do these as part of a language addition
+
+- Do NOT make `enum Language` `public`. It is intentionally internal — the public API always uses `.automatic`. Changing this is a separate API design task.
+- Do NOT edit `Sources/SystemInfoKit/Entities/Values/Temperature.swift`. The `°C` unit is currently hard-coded; localizing it (e.g., Fahrenheit for `en-US`) is a separate feature.
+- Do NOT edit `Package.swift`. Resources are auto-processed via `.process("Resources")`.
+- Do NOT add CI, lint, or translation-completeness scripts. That's a separate infrastructure task.
+- Do NOT edit `Repositories/`, `Entities/Info/`, `SystemInfoObserver.swift`, or `Localizable.swift`.
+
+---
+
+## Done criteria (for the assistant to self-check before reporting completion)
+
+- [ ] `Language.swift` has exactly 2 new lines (one `case`, one `switch` arm).
+- [ ] `Localizable.xcstrings` has the new locale block on all 25 keys, `state: "translated"`.
+- [ ] `ByteDataTests.swift` and `PercentageTests.swift` each gained exactly one `.init(...)` row.
+- [ ] `README.md` "Supported languages" list gained exactly one bullet.
+- [ ] `swift build` clean, `swift test` all green.
+- [ ] `Package.swift` unchanged (verify with `git diff Package.swift`).
+- [ ] User has approved the 25 translations verbatim before the xcstrings edit.

--- a/.claude/skills/add-language/SKILL.md
+++ b/.claude/skills/add-language/SKILL.md
@@ -26,7 +26,7 @@ Ask the user (or infer from their message and confirm) these four values before 
 | Variable | Example | Notes |
 |----------|---------|-------|
 | Language name (English, capitalized) | `Italian` | Used in README's "Supported languages" list |
-| Enum case name | `italian` | lowerCamelCase. Place it near its alphabetical neighbours in `Language.swift`, but the existing enum is not strictly alphabetical (`russian` sits after `vietnamese`), so "near enough to be readable" is the real rule — mirror the same position in both the `enum` body and the `switch` block. |
+| Enum case name | `italian` | lowerCamelCase. Insert it in **strict alphabetical order** among the existing cases (`chineseSimplified` / `chineseTraditional` / `english` / `french` / `german` / `japanese` / `korean` / `russian` / `spanish` / `vietnamese`), and mirror the same position in the `switch` block. |
 | `Locale` initializer | `Locale(languageCode: .italian)` | Pick one form:<br>• `Locale(languageCode: .xxx)` — most languages<br>• `Locale(languageCode: .chinese, script: .hanSimplified)` — scripts<br>• `Locale(languageCode: .portuguese, script: nil, languageRegion: .brazil)` — regional variants |
 | Locale identifier | `it` | The **runtime value** of `<the Locale>.identifier`. Xcstrings uses this string as the block key, and SPM emits the compiled `.lproj` folder with this name. Verify it against Step 1's `Locale`. |
 
@@ -43,7 +43,7 @@ Existing coverage — do not duplicate:
 
 Two edits, both in the same `enum Language`:
 
-**1a. Add the case** in the `enum` body (lines 3–15), placed near its alphabetical neighbours (the existing enum is close to but not strictly alphabetical). For a new `.italian`, it goes between `.german` and `.japanese`:
+**1a. Add the case** in the `enum` body (lines 3–15), preserving strict alphabetical order. For a new `.italian`, it goes between `.german` and `.japanese`:
 
 ```swift
 case german
@@ -51,7 +51,7 @@ case italian    // ← new
 case japanese
 ```
 
-**1b. Add the `switch` arm** in the `var locale: Locale` block (lines 16–41), **at the same relative position** you chose in 1a (Swift 6 checks exhaustiveness, but keeping the order aligned across the two lists is a readability rule):
+**1b. Add the `switch` arm** in the `var locale: Locale` block (lines 16–41), at the same alphabetical position as 1a:
 
 ```swift
 case .german:

--- a/.claude/skills/add-language/SKILL.md
+++ b/.claude/skills/add-language/SKILL.md
@@ -26,7 +26,7 @@ Ask the user (or infer from their message and confirm) these four values before 
 | Variable | Example | Notes |
 |----------|---------|-------|
 | Language name (English, capitalized) | `Italian` | Used in README's "Supported languages" list |
-| Enum case name | `italian` | lowerCamelCase; must sort alphabetically among existing cases (`chineseSimplified` / `chineseTraditional` / `english` / `french` / `german` / `japanese` / `korean` / `russian` / `spanish` / `vietnamese`) |
+| Enum case name | `italian` | lowerCamelCase. Place it near its alphabetical neighbours in `Language.swift`, but the existing enum is not strictly alphabetical (`russian` sits after `vietnamese`), so "near enough to be readable" is the real rule — mirror the same position in both the `enum` body and the `switch` block. |
 | `Locale` initializer | `Locale(languageCode: .italian)` | Pick one form:<br>• `Locale(languageCode: .xxx)` — most languages<br>• `Locale(languageCode: .chinese, script: .hanSimplified)` — scripts<br>• `Locale(languageCode: .portuguese, script: nil, languageRegion: .brazil)` — regional variants |
 | Locale identifier | `it` | The **runtime value** of `<the Locale>.identifier`. Xcstrings uses this string as the block key, and SPM emits the compiled `.lproj` folder with this name. Verify it against Step 1's `Locale`. |
 
@@ -43,7 +43,7 @@ Existing coverage — do not duplicate:
 
 Two edits, both in the same `enum Language`:
 
-**1a. Add the case** in the `enum` body (lines 3–15), preserving alphabetical order. For a new `.italian`, it goes between `.german` and `.japanese`:
+**1a. Add the case** in the `enum` body (lines 3–15), placed near its alphabetical neighbours (the existing enum is close to but not strictly alphabetical). For a new `.italian`, it goes between `.german` and `.japanese`:
 
 ```swift
 case german
@@ -51,7 +51,7 @@ case italian    // ← new
 case japanese
 ```
 
-**1b. Add the `switch` arm** in the `var locale: Locale` block (lines 16–41), same alphabetical position:
+**1b. Add the `switch` arm** in the `var locale: Locale` block (lines 16–41), **at the same relative position** you chose in 1a (Swift 6 checks exhaustiveness, but keeping the order aligned across the two lists is a readability rule):
 
 ```swift
 case .german:
@@ -91,11 +91,17 @@ Rules:
 Generate translations in this order:
 
 1. Read `references/keys.md` for the 25 key list and format constraints.
-2. Read a few existing entries from a linguistically similar language (e.g. for Italian, look at the existing `fr` and `es` blocks) to match the punctuation convention.
-3. Produce all 25 translations at once in a single message, formatted as `key → value` pairs, and ask the user to confirm before writing the file.
-4. Only after confirmation, edit the xcstrings file.
+2. Look up the target-language terminology **Apple actually uses** in the shipping OS UI — Activity Monitor (`Etkinlik Monitörü`, `活动监视器`, `アクティビティモニタ`, …) for `cpu*` / `memory*` / `network*` / `storage*` keys, and System Settings → Battery for `battery*` keys. Apple's own translations are the authoritative reference for this project — align with them when they exist. (Concrete example from the Turkish trial: `Kablolu Bellek` for `memoryWired%@` matches Activity Monitor; `Şarj Döngüsü` / `Boşta` / `Yükleme` / `İndirme` / `Pil` all come straight from Apple's macOS/iOS Turkish UI.)
+3. Read a few existing entries from a linguistically similar language (e.g. for Italian, look at the existing `fr` and `es` blocks) to match punctuation conventions.
+4. Produce all 25 translations at once in a single message, formatted as `key → value` pairs, and ask the user to confirm before writing the file. Flag any keys where you fell back to a general-purpose translation because you could not find Apple's rendering — those are the ones most likely to get corrected.
+5. Only after confirmation, edit the xcstrings file.
 
-Editing approach for the xcstrings file: prefer `Edit` (or many small `Edit` calls) over `Write` — the file is large JSON and a full rewrite risks reordering or reformatting existing entries.
+Editing approach for the xcstrings file. Two viable paths:
+
+- **Many small `Edit` calls** — one per key. Safe for a small changeset, but 25 keys × one Edit each is a lot.
+- **A validated Python script** — read the file with `json.load`, add each new locale block preserving the existing block ordering, dump it back, then convert the JSON `": "` separator back to the Xcode `" : "` style, and round-trip with `json.load` to confirm the result parses and every 25 entries are present with `state: "translated"`. This is what the Turkish trial used; the diff came out to `+151 -1` (25 blocks × 6 lines + a trailing newline) with zero touched existing entries.
+
+Both approaches must preserve the Xcode `" : "` separator. Avoid `Write` on the whole file without validation — it will silently reformat existing entries and produce an unreviewable diff.
 
 ---
 
@@ -194,19 +200,41 @@ swift build
 
 Must succeed with no warnings introduced by the diff.
 
-### 6c. Test the affected suites first, then the full suite
+### 6c. Run tests — **`xcodebuild`, not `swift test`**
+
+This is the single non-obvious step in the whole recipe: for a Swift Package that ships `.xcstrings` or `.xcassets` resources, `swift test` from the CLI does **not** compile the string catalog into per-locale `.strings` files. `Bundle.module` at test time therefore has no localized strings at all, and every `String(localized:)` call returns the key itself (e.g. `"batteryIsNotInstalled"` instead of `"Battery: Not Installed"`). Every Repository test whose assertions include translated text will fail — and it will fail the same way on `main` too, so it is not a signal that your change broke anything.
+
+Use `xcodebuild`:
+
+```bash
+xcodebuild test \
+  -scheme SystemInfoKit \
+  -destination 'platform=macOS' \
+  -skipPackagePluginValidation \
+  -skipMacroValidation \
+  2>&1 | xcpretty
+```
+
+For iOS coverage of the platform-gated code paths:
+
+```bash
+xcodebuild test \
+  -scheme SystemInfoKit \
+  -destination 'platform=iOS Simulator,name=iPhone 16'
+```
+
+All 16 tests across 8 suites must pass. If any Repository test fails with translated strings on both sides, you inadvertently edited an existing translation in `.xcstrings` — revert that change.
+
+### 6d. Fast pre-check with `swift test` (optional)
+
+`swift test --filter ByteDataTests` and `swift test --filter PercentageTests` will still pass under `swift test` because they use `MeasurementFormatter` and `%f` formatting directly, not xcstrings. Use them as a fast sanity check that the new locale case, unit, and decimal separator behave correctly before spinning up `xcodebuild` for the full suite:
 
 ```bash
 swift test --filter ByteDataTests
 swift test --filter PercentageTests
-swift test
 ```
 
-If the two filtered runs fail, cross-check the actual `MeasurementFormatter` / `%.1f` output against your Step 6a scratch output — those are the truth.
-
-### 6d. Repository tests (regression)
-
-Repository tests (`BatteryRepositoryTests` etc.) hard-code English string expectations. They should stay green — if any fail, you inadvertently edited an English translation in `.xcstrings`. Revert that change.
+Do NOT run bare `swift test` and read anything into a Repository-suite failure — it is the environmental issue described in 6c.
 
 ---
 
@@ -216,6 +244,7 @@ Repository tests (`BatteryRepositoryTests` etc.) hard-code English string expect
 - Do NOT edit `Sources/SystemInfoKit/Entities/Values/Temperature.swift`. The `°C` unit is currently hard-coded; localizing it (e.g., Fahrenheit for `en-US`) is a separate feature.
 - Do NOT edit `Package.swift`. Resources are auto-processed via `.process("Resources")`.
 - Do NOT add CI, lint, or translation-completeness scripts. That's a separate infrastructure task.
+- Do NOT swap `xcodebuild` for `swift test` in Step 6c "because it's slower". `swift test` will report Repository suites as failing even when the localization is perfect — see Step 6c.
 - Do NOT edit `Repositories/`, `Entities/Info/`, `SystemInfoObserver.swift`, or `Localizable.swift`.
 
 ---
@@ -226,6 +255,6 @@ Repository tests (`BatteryRepositoryTests` etc.) hard-code English string expect
 - [ ] `Localizable.xcstrings` has the new locale block on all 25 keys, `state: "translated"`.
 - [ ] `ByteDataTests.swift` and `PercentageTests.swift` each gained exactly one `.init(...)` row.
 - [ ] `README.md` "Supported languages" list gained exactly one bullet.
-- [ ] `swift build` clean, `swift test` all green.
+- [ ] `swift build` clean; `xcodebuild test -scheme SystemInfoKit -destination 'platform=macOS'` all green (NOT `swift test` — see Step 6c).
 - [ ] `Package.swift` unchanged (verify with `git diff Package.swift`).
 - [ ] User has approved the 25 translations verbatim before the xcstrings edit.

--- a/.claude/skills/add-language/references/keys.md
+++ b/.claude/skills/add-language/references/keys.md
@@ -1,0 +1,72 @@
+# Localizable.xcstrings — Key Reference
+
+Source of truth: `Sources/SystemInfoKit/Resources/Localizable.xcstrings` (25 keys, `sourceLanguage: "en"`).
+
+Every key below must be present under a new locale, with `state: "translated"`. Keep the format specifiers (`%@`, `%lld`) exactly as in the English source — reorder them within the sentence only if the target language requires it.
+
+## Category: Battery
+
+| Key | English source | Placeholder meaning |
+|-----|----------------|---------------------|
+| `battery` | `Battery` | — |
+| `battery%@` | `Battery: %@` | `%@` = percentage like `"98.2%"` / `"98,2%"` |
+| `batteryIsNotInstalled` | `Battery: Not Installed` | — |
+| `batteryUnknown` | `Unknown` | — |
+| `batteryPowerSource%@` | `Power Source: %@` | `%@` = raw source name (usually English, do not localize the placeholder) |
+| `batteryMaxCapacity%@` | `Max Capacity: %@` | `%@` = percentage |
+| `batteryCycle%lld` | `Cycle Count: %lld` | `%lld` = integer cycle count |
+| `batteryTemperature%@` | `Temperature: %@` | `%@` = temperature string, currently hard-coded `"30.2°C"` format |
+
+## Category: CPU
+
+| Key | English source | Placeholder meaning |
+|-----|----------------|---------------------|
+| `cpu%@` | `CPU: %@` | `%@` = percentage |
+| `cpuSystem%@` | `System: %@` | `%@` = percentage |
+| `cpuUser%@` | `User: %@` | `%@` = percentage |
+| `cpuIdle%@` | `Idle: %@` | `%@` = percentage |
+
+## Category: Memory
+
+| Key | English source | Placeholder meaning |
+|-----|----------------|---------------------|
+| `memory%@` | `Memory: %@` | `%@` = percentage |
+| `memoryPressure%@` | `Pressure: %@` | `%@` = percentage |
+| `memoryApp%@` | `App Memory: %@` | `%@` = byte string like `"6.4 GB"` |
+| `memoryWired%@` | `Wired Memory: %@` | `%@` = byte string |
+| `memoryCompressed%@` | `Compressed: %@` | `%@` = byte string |
+
+## Category: Storage
+
+| Key | English source | Placeholder meaning |
+|-----|----------------|---------------------|
+| `storage%@` | `Storage: %@ used` | `%@` = percentage; the word `used` is a suffix that gets translated |
+
+## Category: Network
+
+| Key | English source | Placeholder meaning |
+|-----|----------------|---------------------|
+| `network%@` | `Network: %@` | `%@` = interface name (`"Ethernet"`, `"Wi-Fi"`, etc. — keep English if the term is universally understood) |
+| `networkCellular` | `Cellular` | — |
+| `networkUnknown` | `Unknown` | — |
+| `networkNoConnection` | `No Connection` | — |
+| `networkLocalIP%@` | `Local IP: %@` | `%@` = IP string |
+| `networkUpload%@` | `Upload: %@/s` | `%@` = byte string. Existing translations keep `/s` as-is (not localized) |
+| `networkDownload%@` | `Download: %@/s` | Same as upload |
+
+## Translation policy (observed from existing locales)
+
+Follow target-language typographic conventions inside the value. Verified samples:
+
+- **French (`fr`)** uses ` : ` — ASCII colon with a space on **both** sides (e.g. `Batterie : %@`, `Envoi : %@/s`).
+- **Japanese (`ja`)** uses `：` — the full-width colon with no surrounding space (e.g. `バッテリー：%@`).
+- **Russian (`ru`)**, **English (`en`)**, **German (`de`)**, **Spanish (`es`)**, **Korean (`ko`)**, **Vietnamese (`vi`)**, **Chinese Simplified/Traditional (`zh-Hans` / `zh-Hant`)** use `: ` — ASCII colon + single trailing space.
+
+Before writing a new locale's translations, **grep existing entries with the same or similar-family language** to match the convention (e.g. for Italian look at `fr` / `es`; for Portuguese look at `es` / `fr`; for Thai / Indonesian check what conventions Apple's own String Catalog defaults show).
+
+Other rules:
+
+- **`/s` in Upload/Download**: Not translated in any existing locale (fr keeps `Envoi : %@/s`, ru keeps `Выгрузка: %@/s`, ja keeps `アップロード：%@/s`). Keep the literal `/s`.
+- **`Unknown`**: `batteryUnknown` and `networkUnknown` are separate keys with the same English source; translate independently (they may share a translation).
+- **`Battery: Not Installed` vs `Battery: %@`**: `batteryIsNotInstalled` is a full standalone sentence — do NOT try to reuse `battery%@` interpolated with "Not Installed".
+- **Placeholder position**: If the target grammar requires reordering, keep the `%@` / `%lld` specifier itself intact — only its position in the sentence may move.

--- a/.claude/skills/add-language/references/keys.md
+++ b/.claude/skills/add-language/references/keys.md
@@ -33,7 +33,7 @@ Every key below must be present under a new locale, with `state: "translated"`. 
 | `memory%@` | `Memory: %@` | `%@` = percentage |
 | `memoryPressure%@` | `Pressure: %@` | `%@` = percentage |
 | `memoryApp%@` | `App Memory: %@` | `%@` = byte string like `"6.4 GB"` |
-| `memoryWired%@` | `Wired Memory: %@` | `%@` = byte string |
+| `memoryWired%@` | `Wired Memory: %@` | `%@` = byte string. **Apple-UI cross-check strongly recommended** — this is technical macOS jargon (kernel-reserved memory that can't be swapped) and existing translations vary widely (de: `Reservierter Speicher`, es: `Memoria física`, fr: `Mémoire résidente`, ja: `確保されているメモリ`, tr: `Kablolu Bellek`). Follow whatever Apple's Activity Monitor uses in the target language rather than translating literally. |
 | `memoryCompressed%@` | `Compressed: %@` | `%@` = byte string |
 
 ## Category: Storage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,11 +12,18 @@ A Swift Package that streams macOS/iOS system telemetry (CPU, memory, storage, b
 
 ```bash
 swift build
-swift test
+
+# Use xcodebuild — NOT `swift test` — for the full test suite.
+xcodebuild test \
+  -scheme SystemInfoKit \
+  -destination 'platform=macOS' \
+  -skipPackagePluginValidation \
+  -skipMacroValidation
 ```
 
 - Test framework is **swift-testing** (`import Testing`, `@Test`, `#expect`, `#require`) — not XCTest.
-- `swift test` on macOS only exercises the macOS branch. iOS-guarded code (`#if os(iOS)` in `BatteryRepository`, `UIDeviceClient`, etc.) needs `xcodebuild -destination 'platform=iOS Simulator,name=<simulator>'`.
+- **Why `xcodebuild` and not `swift test`.** `swift build`/`swift test` from the CLI copies `Localizable.xcstrings` into the bundle but does not compile it into per-locale `.strings`. `Bundle.module` at test time therefore has no localized strings, and every `String(localized:)` call returns the key itself (e.g. `"batteryIsNotInstalled"` instead of `"Battery: Not Installed"`). All Repository suites fail as a result, on `main` too — it is an environmental issue, not a regression. Same rule applies to any Swift Package that ships `.xcstrings` or `.xcassets`. Fast pre-checks that only touch `MeasurementFormatter` / `%f` (e.g. `swift test --filter ByteDataTests`) still work under `swift test`.
+- For iOS-guarded code (`#if os(iOS)` in `BatteryRepository`, `UIDeviceClient`, etc.), swap the destination to `'platform=iOS Simulator,name=<simulator>'`.
 - There is no CI, lint config, formatter, or Makefile. Verification is entirely local.
 
 ## Platforms & Swift version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,100 @@
+# SystemInfoKit — Repository Guide
+
+## What this is
+
+A Swift Package that streams macOS/iOS system telemetry (CPU, memory, storage, battery, network) as an `AsyncStream<SystemInfoBundle>`. Consumers subscribe via a singleton, then start/stop monitoring at their own cadence.
+
+- Public entry point: `Sources/SystemInfoKit/SystemInfoObserver.swift` (use `SystemInfoObserver.shared` — the initializer is intentionally `internal`).
+- Public bundle: `Sources/SystemInfoKit/Entities/SystemInfoBundle.swift`.
+- License: Apache-2.0.
+
+## Build & test
+
+```bash
+swift build
+swift test
+```
+
+- Test framework is **swift-testing** (`import Testing`, `@Test`, `#expect`, `#require`) — not XCTest.
+- `swift test` on macOS only exercises the macOS branch. iOS-guarded code (`#if os(iOS)` in `BatteryRepository`, `UIDeviceClient`, etc.) needs `xcodebuild -destination 'platform=iOS Simulator,name=<simulator>'`.
+- There is no CI, lint config, formatter, or Makefile. Verification is entirely local.
+
+## Platforms & Swift version
+
+From `Package.swift`:
+
+- Swift 6.2 (`// swift-tools-version: 6.2`)
+- `.macOS(.v13)`, `.iOS(.v16)`
+- `defaultLocalization: "en"`, `resources: [.process("Resources")]`
+- Upcoming feature `ExistentialAny` enabled on both target and testTarget — always write `any SystemRepository`, `any CVarArg`, never bare protocol types.
+
+## Architecture at a glance
+
+Four cooperating patterns:
+
+1. **Repository pattern.** Each `SystemInfoType` case is served by one `SystemRepository` conformer under `Sources/SystemInfoKit/Repositories/`. Protocol: `Sources/SystemInfoKit/Repositories/SystemRepository.swift`. Canonical example: `Sources/SystemInfoKit/Repositories/CPURepository.swift`. Standard idiom is `var result = XxxInfo(language: language)` + `defer { stateClient.withLock { $0.bundle.xxxInfo = result } }`.
+
+2. **DI Client pattern** (pointfree-style). Every OS API is wrapped as a `struct XxxClient: DependencyClient` holding `@Sendable` closures with `liveValue` / `testValue`. Aggregated in `Dependencies` (`Sources/SystemInfoKit/Dependencies/Dependencies.swift`). Tests override fields via `testDependency(of: XxxClient.self) { $0.someClosure = { … } }`.
+
+3. **Shared state.** All mutable state lives in `OSAllocatedUnfairLock<State>` behind `StateClient` (`Sources/SystemInfoKit/Dependencies/StateClient.swift`, `Sources/SystemInfoKit/Entities/State.swift`). Repositories read/mutate via `stateClient.withLock { ... }` — they never own state themselves.
+
+4. **Localization via `Localizable` protocol.** `Sources/SystemInfoKit/Localizable.swift` wraps `String(localized:bundle:)`. Every repository and `*Info` conforms and carries a `language: Language`.
+
+## Public vs internal surface
+
+**Public:** `SystemInfoObserver`, `SystemInfoBundle`, `SystemInfoType`, `SystemInfo`, the five `*Info` structs, `Percentage`, `ByteData`, `Temperature`, `NetworkInterface`, `DependencyClient` + `testDependency` helper. Mutable fields on models are `public internal(set) var` so consumers can read but only repositories can write.
+
+**Internal (intentionally):** everything under `Dependencies/`, `Repositories/`, `State`, `Language`, `Localizable`, and all `SystemInfoObserver` initializers except access through `.shared`.
+
+## Testing conventions
+
+- `struct XxxTests { @Test func … }` — swift-testing.
+- Parameterized via `@Test(arguments: [...])` — see `Tests/SystemInfoKitTests/EntityTests/PercentageTests.swift`.
+- `@testable import SystemInfoKit` for internal access.
+- Fixture pattern: build `OSAllocatedUnfairLock<State>`, seed it via `withLock`, then construct the SUT with `.testDependencies(...)` + per-field overrides + `.testDependency(state)`.
+- Repository tests always use `language: .english` for deterministic string expectations.
+- `Tests/SystemInfoKitTests/RepositoryTests/NetworkRepositoryTests.swift` has an inline `NRMock` that fabricates raw `ifaddrs` C structs — the only place raw C pointer fixtures appear.
+
+## Adding a language
+
+Follow `.claude/skills/add-language/SKILL.md` — 5 files change (`Language.swift`, `Localizable.xcstrings`, `ByteDataTests`, `PercentageTests`, `README.md`) and none other. The skill also generates translations and produces a verification checklist.
+
+## Non-obvious gotchas
+
+- **`SystemInfoObserver.init()` is `internal`.** Consumers must go through `SystemInfoObserver.shared`. The two-argument init is for tests only.
+- **`Language` is `internal`.** The public API always runs `.automatic` (system locale). Adding a language does NOT expose the case to consumers.
+- **`systemInfoStream()` is single-consumer** (`bufferingPolicy: .bufferingNewest(1)`). Multiple `for await` loops steal from each other. README documents the fix: wrap with `swift-async-algorithms`' `share()` on the consumer side; the package intentionally does not depend on it.
+- **`monitorInterval` is clamped to `max(interval, 1.0)`** in `SystemInfoObserver.startMonitoring`.
+- **`toggleActivation` re-emits immediately.** Newly enabled types get a zero-placeholder `*Info` right away; newly disabled types get `nil`; unchanged types are untouched.
+- **Two singletons.** `SystemInfoObserver.shared` and `StateClient.liveValue` are independent. A hand-built `SystemInfoObserver(dependencies: .init(), language: ...)` still shares state with `.shared` unless the test also overrides `stateClient`.
+- **Battery has a macOS 27+ / pre-27 split** in `Sources/SystemInfoKit/Repositories/BatteryRepository.swift` (`BatteryData` dict + `AppleSmartBatteryPack` on 27+, flat keys + `AppleRawMaxCapacity` before). Tests only cover the pre-27 branch.
+- **`Temperature` is hard-coded to `°C`** — no Fahrenheit / locale awareness.
+- **`Percentage.width`** (default 4, batteries use 5) is a formatting concern threaded through the model; changing it shifts golden strings in README and repo tests.
+- **`_description` on `SystemInfo`** is intentionally accessible package-wide despite the underscore — `BatteryInfo` uses it to compose `description` conditionally on `isInstalled`.
+- **`String.separate()`** in `Sources/SystemInfoKit/Extensions/String+Extension.swift` uses `RegexBuilder` to split localized byte strings (`"1,5 Go"` / `"1.5 GB"`) for alignment — that's why comma-decimal locales work end-to-end.
+- **`.swiftpm/` is git-ignored but currently checked in** for the workspace stub. Don't rely on its contents.
+- **`PrivacyInfo.xcprivacy`** ships in resources — any change to which SPIs the package reads (IOKit properties, `getifaddrs`, etc.) should be reflected there.
+
+## Where things live
+
+```
+Sources/SystemInfoKit/
+├── SystemInfoObserver.swift        Public façade (singleton).
+├── Localizable.swift               Internal L10n protocol.
+├── Dependencies/                   DI container + typed clients (Host, IOKit, NWPathMonitor, POSIX, State, UIDevice, URLResourceValues).
+├── Entities/
+│   ├── SystemInfoBundle.swift      Public aggregate.
+│   ├── SystemInfoType.swift        Public enum + repositoryType map.
+│   ├── State.swift                 Internal mutable state.
+│   ├── Language.swift              Internal locale + bundle lookup.
+│   ├── Info/                       Public *Info structs (CPU/Memory/Storage/Battery/Network) + SystemInfo protocol.
+│   └── Values/                     Public value types (Percentage, ByteData, Temperature, DataTraffic, NetworkInterface).
+├── Extensions/String+Extension.swift  RegexBuilder split for "1.5 GB".
+├── Repositories/                   One per SystemInfoType.
+└── Resources/                      Localizable.xcstrings + PrivacyInfo.xcprivacy.
+
+Tests/SystemInfoKitTests/
+├── SystemInfoObserverTests.swift
+├── EntityTests/                    ByteData, Percentage.
+└── RepositoryTests/                One per repository.
+```

--- a/Sources/SystemInfoKit/Entities/Language.swift
+++ b/Sources/SystemInfoKit/Entities/Language.swift
@@ -9,9 +9,9 @@ enum Language {
     case german
     case japanese
     case korean
+    case russian
     case spanish
     case vietnamese
-    case russian
 
     var locale: Locale {
         switch self {
@@ -31,12 +31,12 @@ enum Language {
             Locale(languageCode: .japanese)
         case .korean:
             Locale(languageCode: .korean)
+        case .russian:
+            Locale(languageCode: .russian)
         case .spanish:
             Locale(languageCode: .spanish)
         case .vietnamese:
             Locale(languageCode: .vietnamese)
-        case .russian:
-            Locale(languageCode: .russian)
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` at the repository root: a one-page orientation covering build/test commands, the Repository + DI Client + `OSAllocatedUnfairLock<State>` + `Localizable` architecture, public/internal API split, swift-testing conventions, and non-obvious gotchas (`SystemInfoObserver.shared`-only access, single-consumer `AsyncStream`, macOS 27 battery split, hard-coded `°C`, etc.).
- Add `.claude/skills/add-language/` — a project-scoped Claude Skill that codifies the exact 5-file recipe for adding a new language so translations no longer silently fall back to English when a key or a test row is missed:
  - `Sources/SystemInfoKit/Entities/Language.swift` — enum case + `Locale` mapping
  - `Sources/SystemInfoKit/Resources/Localizable.xcstrings` — all 25 keys under the new locale
  - `Tests/SystemInfoKitTests/EntityTests/ByteDataTests.swift` — unit and decimal-separator expectation row
  - `Tests/SystemInfoKitTests/EntityTests/PercentageTests.swift` — decimal-separator expectation row
  - `README.md` — Supported languages list
- Ship a `references/keys.md` sidecar with the 25 keys, format specifiers, and observed per-language typographic conventions (`fr` uses ` : `, `ja` uses `：`, others `: `).

The skill also gathers the four required inputs up front (English name, enum case, `Locale` initializer, `Locale.identifier`), generates translations for user confirmation before touching the xcstrings file, and forces a `swift build` + `swift test` verification pass — including a locale-identifier check that catches the common failure mode of an xcstrings block landing under the wrong `.lproj`.

No product source or tests are touched; existing behavior and CI (there is none) are unchanged.