### PR TITLE
Fix Mach port lifecycle in BatteryRepository and host info

### DIFF
--- a/Sources/SystemInfoKit/Dependencies/HostClient.swift
+++ b/Sources/SystemInfoKit/Dependencies/HostClient.swift
@@ -1,19 +1,33 @@
 import Darwin
 
 struct HostClient: DependencyClient {
+    var hostSelf: @Sendable () -> host_t
+    var deallocatePort: @Sendable (host_t) -> kern_return_t
     var statistics64: @Sendable (host_t, host_flavor_t, host_info_t?, UnsafeMutablePointer<mach_msg_type_number_t>?) -> kern_return_t
     var pageSize: @Sendable (host_t, UnsafeMutablePointer<vm_size_t>?) -> kern_return_t
     var info: @Sendable (host_t, host_flavor_t, host_info_t?, UnsafeMutablePointer<mach_msg_type_number_t>?) -> kern_return_t
 
     static let liveValue = Self(
+        hostSelf: { mach_host_self() },
+        deallocatePort: { mach_port_deallocate(mach_task_self_, $0) },
         statistics64: { host_statistics64($0, $1, $2, $3) },
         pageSize: { host_page_size($0, $1) },
         info: { host_info($0, $1, $2, $3) }
     )
 
     static let testValue = Self(
+        hostSelf: { HOST_NULL },
+        deallocatePort: { _ in KERN_FAILURE },
         statistics64: { _, _, _, _ in KERN_FAILURE },
         pageSize: { _, _ in KERN_FAILURE },
         info: { _, _, _, _ in KERN_FAILURE }
     )
+}
+
+extension HostClient {
+    func withHostPort<R>(_ body: (host_t) -> R) -> R {
+        let host = hostSelf()
+        defer { _ = deallocatePort(host) }
+        return body(host)
+    }
 }

--- a/Sources/SystemInfoKit/Dependencies/IOKitClient.swift
+++ b/Sources/SystemInfoKit/Dependencies/IOKitClient.swift
@@ -3,20 +3,17 @@ import IOKit
 
 struct IOKitClient: DependencyClient {
     var getMatchingService: @Sendable (mach_port_t, CFDictionary) -> io_service_t
-    var close: @Sendable (io_service_t) -> kern_return_t
     var release: @Sendable (io_object_t) -> kern_return_t
     var registryEntryCreateCFProperties: @Sendable (io_registry_entry_t, UnsafeMutablePointer<Unmanaged<CFMutableDictionary>?>?, CFAllocator?, IOOptionBits) -> kern_return_t
 
     static let liveValue = Self(
         getMatchingService: { IOServiceGetMatchingService($0, $1) },
-        close: { IOServiceClose($0) },
         release: { IOObjectRelease($0) },
         registryEntryCreateCFProperties: { IORegistryEntryCreateCFProperties($0, $1, $2, $3) }
     )
 
     static let testValue = Self(
         getMatchingService: { _, _ in IO_OBJECT_NULL },
-        close: { _ in kIOReturnError },
         release: { _ in kIOReturnError },
         registryEntryCreateCFProperties: { _, _, _, _ in kIOReturnError }
     )

--- a/Sources/SystemInfoKit/Repositories/BatteryRepository.swift
+++ b/Sources/SystemInfoKit/Repositories/BatteryRepository.swift
@@ -15,23 +15,18 @@ struct BatteryRepository: SystemRepository {
     }
 
     private func fetchIOServiceProperties(name: String) -> [String: AnyObject]? {
-        // Open Connection
         let service = ioKitClient.getMatchingService(kIOMainPortDefault, IOServiceNameMatching(name))
         guard service != IO_OBJECT_NULL else {
             return nil
         }
         defer {
-            _ = ioKitClient.close(service)
             _ = ioKitClient.release(service)
         }
-        // Read Dictionary Data
         var props: Unmanaged<CFMutableDictionary>? = nil
-        guard ioKitClient.registryEntryCreateCFProperties(service, &props, kCFAllocatorDefault, .zero) == kIOReturnSuccess,
-              let dict = props?.takeUnretainedValue() as? [String: AnyObject] else {
+        guard ioKitClient.registryEntryCreateCFProperties(service, &props, kCFAllocatorDefault, .zero) == kIOReturnSuccess else {
             return nil
         }
-        props?.release()
-        return dict
+        return props?.takeRetainedValue() as? [String: AnyObject]
     }
 
     func update() async {

--- a/Sources/SystemInfoKit/Repositories/CPURepository.swift
+++ b/Sources/SystemInfoKit/Repositories/CPURepository.swift
@@ -16,7 +16,9 @@ struct CPURepository: SystemRepository {
         var size: mach_msg_type_number_t = UInt32(MemoryLayout<host_cpu_load_info_data_t>.size / MemoryLayout<integer_t>.size)
         let hostInfo = host_cpu_load_info_t.allocate(capacity: 1)
         let result = hostInfo.withMemoryRebound(to: integer_t.self, capacity: Int(size)) { pointer in
-            hostClient.statistics64(mach_host_self(), HOST_CPU_LOAD_INFO, pointer, &size)
+            hostClient.withHostPort { host in
+                hostClient.statistics64(host, HOST_CPU_LOAD_INFO, pointer, &size)
+            }
         }
         let data = if result == KERN_SUCCESS {
             hostInfo.move()

--- a/Sources/SystemInfoKit/Repositories/MemoryRepository.swift
+++ b/Sources/SystemInfoKit/Repositories/MemoryRepository.swift
@@ -17,7 +17,9 @@ struct MemoryRepository: SystemRepository {
         var statistics = vm_statistics64()
         _ = withUnsafeMutablePointer(to: &statistics) { pointer in
             pointer.withMemoryRebound(to: integer_t.self, capacity: Int(size)) { pointer in
-                hostClient.statistics64(mach_host_self(), HOST_VM_INFO64, pointer, &size)
+                hostClient.withHostPort { host in
+                    hostClient.statistics64(host, HOST_VM_INFO64, pointer, &size)
+                }
             }
         }
         return statistics
@@ -26,7 +28,9 @@ struct MemoryRepository: SystemRepository {
     private var pageSize: vm_size_t {
         var size = vm_size_t()
         _ = withUnsafeMutablePointer(to: &size) { pointer in
-            hostClient.pageSize(mach_host_self(), pointer)
+            hostClient.withHostPort { host in
+                hostClient.pageSize(host, pointer)
+            }
         }
         return size
     }
@@ -36,7 +40,9 @@ struct MemoryRepository: SystemRepository {
         var basicInfo = host_basic_info()
         _ = withUnsafeMutablePointer(to: &basicInfo) { pointer in
             pointer.withMemoryRebound(to: integer_t.self, capacity: Int(size)) { pointer in
-                hostClient.info(mach_host_self(), HOST_BASIC_INFO, pointer, &size)
+                hostClient.withHostPort { host in
+                    hostClient.info(host, HOST_BASIC_INFO, pointer, &size)
+                }
             }
         }
         return basicInfo

--- a/Tests/SystemInfoKitTests/RepositoryTests/BatteryRepositoryTests.swift
+++ b/Tests/SystemInfoKitTests/RepositoryTests/BatteryRepositoryTests.swift
@@ -72,6 +72,41 @@ struct BatteryRepositoryTests {
     }
 
     @Test
+    func update_releases_every_io_service_exactly_once() async throws {
+        let state = OSAllocatedUnfairLock<State>(initialState: .init())
+        let matchedServices = OSAllocatedUnfairLock<[io_service_t]>(initialState: [])
+        let releasedObjects = OSAllocatedUnfairLock<[io_object_t]>(initialState: [])
+        let sut = BatteryRepository(
+            .testDependencies(
+                ioKitClient: testDependency(of: IOKitClient.self) {
+                    $0.getMatchingService = { _, _ in
+                        matchedServices.withLock { services in
+                            let service = io_service_t(services.count + 1)
+                            services.append(service)
+                            return service
+                        }
+                    }
+                    $0.release = { object in
+                        releasedObjects.withLock { objects in objects.append(object) }
+                        return kIOReturnSuccess
+                    }
+                    $0.registryEntryCreateCFProperties = { _, pointer, _, _ in
+                        let dict = NSMutableDictionary(dictionary: [
+                            "BatteryInstalled" : NSNumber(booleanLiteral: true),
+                        ])
+                        pointer?.pointee = Unmanaged.passRetained(dict)
+                        return kIOReturnSuccess
+                    }
+                },
+                stateClient: .testDependency(state)
+            ),
+            language: .english
+        )
+        await sut.update()
+        #expect(releasedObjects.withLock(\.self) == matchedServices.withLock(\.self))
+    }
+
+    @Test
     func reset() {
         let state = OSAllocatedUnfairLock<State>(initialState: .init())
         state.withLock { $0.bundle.batteryInfo = .zero }

--- a/Tests/SystemInfoKitTests/RepositoryTests/CPURepositoryTests.swift
+++ b/Tests/SystemInfoKitTests/RepositoryTests/CPURepositoryTests.swift
@@ -37,6 +37,33 @@ struct CPURepositoryTests {
     }
 
     @Test
+    func update_deallocates_every_host_port() async throws {
+        let state = OSAllocatedUnfairLock<State>(initialState: .init())
+        let acquiredCount = OSAllocatedUnfairLock<Int>(initialState: 0)
+        let deallocatedCount = OSAllocatedUnfairLock<Int>(initialState: 0)
+        let sut = CPURepository(
+            .testDependencies(
+                hostClient: testDependency(of: HostClient.self) {
+                    $0.hostSelf = {
+                        acquiredCount.withLock { count in count += 1 }
+                        return 1
+                    }
+                    $0.deallocatePort = { _ in
+                        deallocatedCount.withLock { count in count += 1 }
+                        return KERN_SUCCESS
+                    }
+                    $0.statistics64 = { _, _, _, _ in KERN_SUCCESS }
+                },
+                stateClient: .testDependency(state)
+            ),
+            language: .english
+        )
+        await sut.update()
+        #expect(acquiredCount.withLock(\.self) == 1)
+        #expect(deallocatedCount.withLock(\.self) == 1)
+    }
+
+    @Test
     func reset() {
         let state = OSAllocatedUnfairLock<State>(initialState: .init())
         state.withLock {

--- a/Tests/SystemInfoKitTests/RepositoryTests/MemoryRepositoryTests.swift
+++ b/Tests/SystemInfoKitTests/RepositoryTests/MemoryRepositoryTests.swift
@@ -47,6 +47,35 @@ struct MemoryRepositoryTests {
     }
 
     @Test
+    func update_deallocates_every_host_port() async throws {
+        let state = OSAllocatedUnfairLock<State>(initialState: .init())
+        let acquiredCount = OSAllocatedUnfairLock<Int>(initialState: 0)
+        let deallocatedCount = OSAllocatedUnfairLock<Int>(initialState: 0)
+        let sut = MemoryRepository(
+            .testDependencies(
+                hostClient: testDependency(of: HostClient.self) {
+                    $0.hostSelf = {
+                        acquiredCount.withLock { count in count += 1 }
+                        return 1
+                    }
+                    $0.deallocatePort = { _ in
+                        deallocatedCount.withLock { count in count += 1 }
+                        return KERN_SUCCESS
+                    }
+                    $0.statistics64 = { _, _, _, _ in KERN_SUCCESS }
+                    $0.info = { _, _, _, _ in KERN_SUCCESS }
+                    $0.pageSize = { _, _ in KERN_SUCCESS }
+                },
+                stateClient: .testDependency(state)
+            ),
+            language: .english
+        )
+        await sut.update()
+        #expect(acquiredCount.withLock(\.self) == 3)
+        #expect(deallocatedCount.withLock(\.self) == 3)
+    }
+
+    @Test
     func reset() {
         let state = OSAllocatedUnfairLock<State>(initialState: .init())
         state.withLock { $0.bundle.memoryInfo = .zero }


### PR DESCRIPTION
## Why

RunCat Neo crashes on launch on macOS 27.0 beta with `EXC_GUARD / GUARD_TYPE_MACH_PORT / INVALID_NAME on mach port` (runcat-dev/RunCatNeo#65). Symbolicating the reported crash offsets against the shipped dSYM pointed at `BatteryRepository.fetchIOServiceProperties(name:)`, and disassembly showed the faulting call was the second of the two calls in its `defer` block.

`IOServiceClose` destroys the port itself — `IOKitLib.h` states "It will be destroyed by this function, and should not be released with `IOObjectRelease`" — and it is meant for the `io_connect_t` returned by `IOServiceOpen`, not for the `io_service_t` returned by `IOServiceGetMatchingService`. So `close` followed by `release` deallocated the same port name twice.

Verified on macOS 26 with a standalone probe:

| sequence | result |
| --- | --- |
| `IOObjectRelease` only | `KERN_SUCCESS` (0) |
| `IOServiceClose` then `IOObjectRelease` | `kIOReturnBadArgument` (0xE00002C2), then `KERN_INVALID_NAME` (15) |

macOS 26 merely returned `KERN_INVALID_NAME`; macOS 27 escalates it to a fatal `EXC_GUARD`. Machines without a battery are unaffected because `IOServiceGetMatchingService` returns `IO_OBJECT_NULL` and the function returns early.

While auditing the surrounding Mach port usage, `CPURepository` and `MemoryRepository` turned out to call `mach_host_self()` four times per tick without ever deallocating the send right. Each call adds a user reference, so a resident app leaks them indefinitely.

## What changed

- Drop the `IOServiceClose` call from `BatteryRepository.fetchIOServiceProperties(name:)`, and remove the now-unused `IOKitClient.close`. Keeping a `close` that takes an `io_service_t` would only invite the same misuse again.
- Take ownership of the properties dictionary with `takeRetainedValue()`, which also fixes a leak on the path where the dictionary cast failed.
- Add `hostSelf` / `deallocatePort` to `HostClient` and route every `mach_host_self()` through `withHostPort`, so acquisition and deallocation stay paired.

## Tests

- `BatteryRepositoryTests.update_releases_every_io_service_exactly_once` — hands out a distinct `io_service_t` per match and asserts the released objects match the matched services exactly.
- `CPURepositoryTests` / `MemoryRepositoryTests` `update_deallocates_every_host_port` — asserts host port acquisitions and deallocations balance.

`xcodebuild test -scheme SystemInfoKit -destination 'platform=macOS'`: 19 tests in 8 suites, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)