### PR TITLE
Added Measured Values of Battery

### DIFF
--- a/MeasuredValues/AppleSmartBattery/MacBook_Air_M2_macOS_27.txt
+++ b/MeasuredValues/AppleSmartBattery/MacBook_Air_M2_macOS_27.txt
@@ -1,0 +1,811 @@
+.
+├── AdapterDetails
+│   ├── AdapterID
+│   │   └── 28675
+│   ├── AdapterPowerTier
+│   │   └── 2
+│   ├── AdapterVoltage
+│   │   └── 20000
+│   ├── Current
+│   │   └── 1490
+│   ├── Description
+│   │   └── pd charger
+│   ├── FamilyCode
+│   │   └── -536854518
+│   ├── FwVersion
+│   │   └── 01030053
+│   ├── HwVersion
+│   │   └── 1.0
+│   ├── IsWireless
+│   │   └── 0
+│   ├── Manufacturer
+│   │   └── Apple Inc.
+│   ├── Model
+│   │   └── 0x7003
+│   ├── Name
+│   │   └── 30W USB-C Power Adapter
+│   ├── PMUConfiguration
+│   │   └── 1490
+│   ├── SerialString
+│   │   └── C4H2211000LLV74AM
+│   ├── UsbHvcHvcIndex
+│   │   └── 3
+│   ├── UsbHvcMenu
+│   │   ├── .
+│   │   │   ├── Index
+│   │   │   │   └── 0
+│   │   │   ├── MaxCurrent
+│   │   │   │   └── 2960
+│   │   │   └── MaxVoltage
+│   │   │       └── 5000
+│   │   ├── .
+│   │   │   ├── Index
+│   │   │   │   └── 1
+│   │   │   ├── MaxCurrent
+│   │   │   │   └── 2980
+│   │   │   └── MaxVoltage
+│   │   │       └── 9000
+│   │   ├── .
+│   │   │   ├── Index
+│   │   │   │   └── 2
+│   │   │   ├── MaxCurrent
+│   │   │   │   └── 1990
+│   │   │   └── MaxVoltage
+│   │   │       └── 15000
+│   │   └── .
+│   │       ├── Index
+│   │       │   └── 3
+│   │       ├── MaxCurrent
+│   │       │   └── 1490
+│   │       └── MaxVoltage
+│   │           └── 20000
+│   └── Watts
+│       └── 30
+├── AdapterInfo
+│   └── 0
+├── Amperage
+│   └── 2019
+├── AppleRawAdapterDetails
+│   └── .
+│       ├── AdapterID
+│       │   └── 28675
+│       ├── AdapterPowerTier
+│       │   └── 2
+│       ├── AdapterVoltage
+│       │   └── 20000
+│       ├── Current
+│       │   └── 1490
+│       ├── Description
+│       │   └── pd charger
+│       ├── FamilyCode
+│       │   └── -536854518
+│       ├── FwVersion
+│       │   └── 01030053
+│       ├── HwVersion
+│       │   └── 1.0
+│       ├── IsWireless
+│       │   └── 0
+│       ├── Manufacturer
+│       │   └── Apple Inc.
+│       ├── Model
+│       │   └── 0x7003
+│       ├── Name
+│       │   └── 30W USB-C Power Adapter
+│       ├── PMUConfiguration
+│       │   └── 1490
+│       ├── SerialString
+│       │   └── C4H2211000LLV74AM
+│       ├── UsbHvcHvcIndex
+│       │   └── 3
+│       ├── UsbHvcMenu
+│       │   ├── .
+│       │   │   ├── Index
+│       │   │   │   └── 0
+│       │   │   ├── MaxCurrent
+│       │   │   │   └── 2960
+│       │   │   └── MaxVoltage
+│       │   │       └── 5000
+│       │   ├── .
+│       │   │   ├── Index
+│       │   │   │   └── 1
+│       │   │   ├── MaxCurrent
+│       │   │   │   └── 2980
+│       │   │   └── MaxVoltage
+│       │   │       └── 9000
+│       │   ├── .
+│       │   │   ├── Index
+│       │   │   │   └── 2
+│       │   │   ├── MaxCurrent
+│       │   │   │   └── 1990
+│       │   │   └── MaxVoltage
+│       │   │       └── 15000
+│       │   └── .
+│       │       ├── Index
+│       │       │   └── 3
+│       │       ├── MaxCurrent
+│       │       │   └── 1490
+│       │       └── MaxVoltage
+│       │           └── 20000
+│       └── Watts
+│           └── 30
+├── AppleRawBatteryVoltage
+│   └── 11842
+├── AppleRawExternalConnected
+│   └── 1
+├── AtCriticalLevel
+│   └── 0
+├── AvgTimeToEmpty
+│   └── 65535
+├── AvgTimeToFull
+│   └── 160
+├── BatteryData
+│   ├── AbsoluteCapacity
+│   │   └── 0
+│   ├── AvgTimeToEmpty
+│   │   └── 65535
+│   ├── BatteryPower
+│   │   └── 23908
+│   ├── CurrentCapacity
+│   │   └── 34
+│   ├── DesignCapacity
+│   │   └── 4563
+│   ├── FullChargeCapacity
+│   │   └── 4427
+│   ├── FullyCharged
+│   │   └── 0
+│   ├── MaxCapacity
+│   │   └── 100
+│   ├── NominalChargeCapacity
+│   │   └── 4554
+│   ├── RemainingCapacity
+│   │   └── 1461
+│   └── TrueRemainingCapacity
+│       └── 0
+├── BatteryInstalled
+│   └── 1
+├── BatteryInvalidWakeSeconds
+│   └── 30
+├── BatteryPackCount
+│   └── 1
+├── BestAdapterIndex
+│   └── 0
+├── BootPathUpdated
+│   └── 1785304221
+├── BootVoltage
+│   └── 0
+├── ChargerConfiguration
+│   └── 1416
+├── ChargerCount
+│   └── 1
+├── ChargerData
+│   ├── IsCharging
+│   │   └── 1
+│   ├── NotChargingReason
+│   │   └── 0
+│   ├── PMUConfiguration
+│   │   └── 1490
+│   ├── PMUConfigured
+│   │   └── 1416
+│   ├── SlowChargingReason
+│   │   └── 0
+│   └── TimeChargingThermallyLimited
+│       └── 0
+├── CurrentCapacity
+│   └── 34
+├── CycleCount
+│   └── 37
+├── DeadBatteryBootData
+│   ├── ActivePayloads
+│   │   └── 3
+│   ├── GeneralPayload
+│   │   ├── AdapterType
+│   │   │   └── 0
+│   │   ├── AverageBattSkinTemp
+│   │   │   └── 0
+│   │   ├── AverageBattVirtualTemp
+│   │   │   └── 0
+│   │   ├── CloakEntryCount
+│   │   │   └── 0
+│   │   ├── PrechargeCount
+│   │   │   └── 0
+│   │   ├── StartBatteryCapacity
+│   │   │   └── 0
+│   │   ├── StartBatteryVoltage
+│   │   │   └── 0
+│   │   ├── TimeOnCharger
+│   │   │   └── 0
+│   │   ├── VbusType
+│   │   │   └── 0
+│   │   └── WirelessChargingMode
+│   │       └── 0
+│   └── SMCBootManagementPayload
+│       ├── APBootCount
+│       │   └── 0
+│       ├── AdapterPower
+│       │   └── 0
+│       ├── DeviceResetCount
+│       │   └── 0
+│       ├── DisplayTimeBootCount
+│       │   └── 0
+│       ├── HighPoweriBootCount
+│       │   └── 0
+│       ├── InstantBootAdapterReady
+│       │   └── 0
+│       ├── InstantBootCount
+│       │   └── 0
+│       ├── InstantBootFailure
+│       │   └── 0
+│       ├── InstantBootGGReady
+│       │   └── 0
+│       └── Ok2SwitchCount
+│           └── 0
+├── DesignCycleCount9C
+│   └── 1000
+├── DeviceName
+│   └── bq40z651
+├── ExternalChargeCapable
+│   └── 1
+├── ExternalConnected
+│   └── 1
+├── FedDetails
+│   ├── .
+│   │   ├── FedDesignCapacity
+│   │   │   └── 0
+│   │   ├── FedDualRolePower
+│   │   │   └── 0
+│   │   ├── FedExternalConnected
+│   │   │   └── 0
+│   │   ├── FedPdSpecRevision
+│   │   │   └── 0
+│   │   ├── FedPortPowerRole
+│   │   │   └── 0
+│   │   ├── FedProductID
+│   │   │   └── 0
+│   │   ├── FedPwrPolicySt
+│   │   │   └── 0
+│   │   ├── FedRemainingCapacity
+│   │   │   └── 0
+│   │   ├── FedSnkConfReason
+│   │   │   └── 0
+│   │   ├── FedSrcConfReason
+│   │   │   └── 0
+│   │   ├── FedStateOfCharge
+│   │   │   └── 0
+│   │   └── FedVendorID
+│   │       └── 0
+│   ├── .
+│   │   ├── FedDesignCapacity
+│   │   │   └── 0
+│   │   ├── FedDualRolePower
+│   │   │   └── 0
+│   │   ├── FedExternalConnected
+│   │   │   └── 0
+│   │   ├── FedPdSpecRevision
+│   │   │   └── 0
+│   │   ├── FedPortPowerRole
+│   │   │   └── 0
+│   │   ├── FedProductID
+│   │   │   └── 0
+│   │   ├── FedPwrPolicySt
+│   │   │   └── 0
+│   │   ├── FedRemainingCapacity
+│   │   │   └── 0
+│   │   ├── FedSnkConfReason
+│   │   │   └── 0
+│   │   ├── FedSrcConfReason
+│   │   │   └── 0
+│   │   ├── FedStateOfCharge
+│   │   │   └── 0
+│   │   └── FedVendorID
+│   │       └── 0
+│   └── .
+│       ├── FedDesignCapacity
+│       │   └── 0
+│       ├── FedDualRolePower
+│       │   └── 0
+│       ├── FedExternalConnected
+│       │   └── 1
+│       ├── FedPdSpecRevision
+│       │   └── 1
+│       ├── FedPortPowerRole
+│       │   └── 0
+│       ├── FedProductID
+│       │   └── 0
+│       ├── FedPwrPolicySt
+│       │   └── 0
+│       ├── FedRemainingCapacity
+│       │   └── 0
+│       ├── FedSnkConfReason
+│       │   └── 0
+│       ├── FedSrcConfReason
+│       │   └── 0
+│       ├── FedStateOfCharge
+│       │   └── 0
+│       └── FedVendorID
+│           └── 0
+├── FullPathUpdated
+│   └── 1785304833
+├── FullyCharged
+│   └── 0
+├── IOGeneralInterest
+│   └── IOCommand is not serializable
+├── IOReportLegend
+│   └── .
+│       ├── IOReportChannelInfo
+│       │   └── IOReportChannelUnit
+│       │       └── 0
+│       ├── IOReportChannels
+│       │   └── .
+│       │       ├── 7167869599145487988
+│       │       ├── 6460407809
+│       │       └── BatteryCycleCount
+│       └── IOReportGroupName
+│           └── Battery
+├── IOReportLegendPublic
+│   └── 1
+├── InstantAmperage
+│   └── 2019
+├── IsCharging
+│   └── 1
+├── Location
+│   └── 0
+├── ManufacturerData
+│   └── {length = 32, bytes = 0x00000000 0b000100 f9140000 04323231 ... 4c002800 00000000 }
+├── MaxCapacity
+│   └── 100
+├── PortControllerInfo
+│   ├── .
+│   │   ├── PortControllerActiveContractRdo
+│   │   │   └── 0
+│   │   ├── PortControllerAttachCount
+│   │   │   └── 0
+│   │   ├── PortControllerBootFlags
+│   │   │   └── 0
+│   │   ├── PortControllerCapMismatch
+│   │   │   └── 0
+│   │   ├── PortControllerDataRoleSwapCount
+│   │   │   └── 0
+│   │   ├── PortControllerDataRoleSwapFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerDetachCount
+│   │   │   └── 0
+│   │   ├── PortControllerDnSt
+│   │   │   └── 0
+│   │   ├── PortControllerElectionFailReason
+│   │   │   └── 0
+│   │   ├── PortControllerEvtBuffer
+│   │   │   └── {length = 120, bytes = 0x00000000 00000000 00000000 00000000 ... 00000000 00000000 }
+│   │   ├── PortControllerFetStatus
+│   │   │   └── 0
+│   │   ├── PortControllerFwVersion
+│   │   │   └── 3154688
+│   │   ├── PortControllerHardResetCount
+│   │   │   └── 0
+│   │   ├── PortControllerHvEnRecoveryCount
+│   │   │   └── 0
+│   │   ├── PortControllerI2cErrCount
+│   │   │   └── 0
+│   │   ├── PortControllerInpFetEnFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntAlert
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntAppLd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntConSrc
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntHrdRst
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPdStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPlg
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPwrStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxIdSop
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxRdo
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxSnkCap
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxSrcCap
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUsb2Plg
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUsb2Wak
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUvdmEnum
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUvdmStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntldcm
+│   │   │   └── 0
+│   │   ├── PortControllerLoserReason
+│   │   │   └── 1
+│   │   ├── PortControllerMaxPower
+│   │   │   └── 0
+│   │   ├── PortControllerNEprPDOs
+│   │   │   └── 0
+│   │   ├── PortControllerNPDOs
+│   │   │   └── 0
+│   │   ├── PortControllerPDst
+│   │   │   └── 0
+│   │   ├── PortControllerPortMode
+│   │   │   └── 2
+│   │   ├── PortControllerPortPDO
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   └── 0
+│   │   ├── PortControllerPowerState
+│   │   │   └── 255
+│   │   ├── PortControllerPwrRoleSwapCount
+│   │   │   └── 0
+│   │   ├── PortControllerPwrRoleSwapFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerShortDetectCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrcTypes
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoRejectCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoRetryCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdyCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdyRejectCount
+│   │   │   └── 0
+│   │   ├── PortControllerStuckCmdCount
+│   │   │   └── 0
+│   │   ├── PortControllerSurpriseAckCount
+│   │   │   └── 0
+│   │   ├── PortControllerSurpriseNackCount
+│   │   │   └── 0
+│   │   ├── PortControllerUvdmStatus
+│   │   │   └── 0
+│   │   ├── PortControllerVdoFailCount
+│   │   │   └── 0
+│   │   └── PortControllerWakeFailCount
+│   │       └── 0
+│   ├── .
+│   │   ├── PortControllerActiveContractRdo
+│   │   │   └── 0
+│   │   ├── PortControllerAttachCount
+│   │   │   └── 0
+│   │   ├── PortControllerBootFlags
+│   │   │   └── 0
+│   │   ├── PortControllerCapMismatch
+│   │   │   └── 0
+│   │   ├── PortControllerDataRoleSwapCount
+│   │   │   └── 0
+│   │   ├── PortControllerDataRoleSwapFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerDetachCount
+│   │   │   └── 0
+│   │   ├── PortControllerDnSt
+│   │   │   └── 0
+│   │   ├── PortControllerElectionFailReason
+│   │   │   └── 0
+│   │   ├── PortControllerEvtBuffer
+│   │   │   └── {length = 120, bytes = 0x00000000 00000000 00000000 00000000 ... 00000000 00000101 }
+│   │   ├── PortControllerFetStatus
+│   │   │   └── 0
+│   │   ├── PortControllerFwVersion
+│   │   │   └── 3154688
+│   │   ├── PortControllerHardResetCount
+│   │   │   └── 0
+│   │   ├── PortControllerHvEnRecoveryCount
+│   │   │   └── 0
+│   │   ├── PortControllerI2cErrCount
+│   │   │   └── 0
+│   │   ├── PortControllerInpFetEnFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntAlert
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntAppLd
+│   │   │   └── 1
+│   │   ├── PortControllerIrqCntConSrc
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntHrdRst
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPdStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPlg
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPwrStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxIdSop
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxRdo
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxSnkCap
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxSrcCap
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUsb2Plg
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUsb2Wak
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUvdmEnum
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUvdmStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntldcm
+│   │   │   └── 0
+│   │   ├── PortControllerLoserReason
+│   │   │   └── 1
+│   │   ├── PortControllerMaxPower
+│   │   │   └── 0
+│   │   ├── PortControllerNEprPDOs
+│   │   │   └── 0
+│   │   ├── PortControllerNPDOs
+│   │   │   └── 0
+│   │   ├── PortControllerPDst
+│   │   │   └── 0
+│   │   ├── PortControllerPortMode
+│   │   │   └── 2
+│   │   ├── PortControllerPortPDO
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   └── 0
+│   │   ├── PortControllerPowerState
+│   │   │   └── 255
+│   │   ├── PortControllerPwrRoleSwapCount
+│   │   │   └── 0
+│   │   ├── PortControllerPwrRoleSwapFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerShortDetectCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrcTypes
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoRejectCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoRetryCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdyCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdyRejectCount
+│   │   │   └── 0
+│   │   ├── PortControllerStuckCmdCount
+│   │   │   └── 0
+│   │   ├── PortControllerSurpriseAckCount
+│   │   │   └── 0
+│   │   ├── PortControllerSurpriseNackCount
+│   │   │   └── 0
+│   │   ├── PortControllerUvdmStatus
+│   │   │   └── 0
+│   │   ├── PortControllerVdoFailCount
+│   │   │   └── 0
+│   │   └── PortControllerWakeFailCount
+│   │       └── 0
+│   └── .
+│       ├── PortControllerActiveContractRdo
+│       │   └── 889396524
+│       ├── PortControllerAttachCount
+│       │   └── 0
+│       ├── PortControllerBootFlags
+│       │   └── 0
+│       ├── PortControllerCapMismatch
+│       │   └── 0
+│       ├── PortControllerDataRoleSwapCount
+│       │   └── 0
+│       ├── PortControllerDataRoleSwapFailCount
+│       │   └── 0
+│       ├── PortControllerDetachCount
+│       │   └── 0
+│       ├── PortControllerDnSt
+│       │   └── 17
+│       ├── PortControllerElectionFailReason
+│       │   └── 0
+│       ├── PortControllerEvtBuffer
+│       │   └── {length = 120, bytes = 0x00000000 00000000 00000000 00000000 ... 1a30485f 5f5e015f }
+│       ├── PortControllerFetStatus
+│       │   └── 140
+│       ├── PortControllerFwVersion
+│       │   └── 3154688
+│       ├── PortControllerHardResetCount
+│       │   └── 0
+│       ├── PortControllerHvEnRecoveryCount
+│       │   └── 0
+│       ├── PortControllerI2cErrCount
+│       │   └── 0
+│       ├── PortControllerInpFetEnFailCount
+│       │   └── 0
+│       ├── PortControllerIrqCntAlert
+│       │   └── 0
+│       ├── PortControllerIrqCntAppLd
+│       │   └── 0
+│       ├── PortControllerIrqCntConSrc
+│       │   └── 0
+│       ├── PortControllerIrqCntHrdRst
+│       │   └── 0
+│       ├── PortControllerIrqCntPdStsUpd
+│       │   └── 0
+│       ├── PortControllerIrqCntPlg
+│       │   └── 0
+│       ├── PortControllerIrqCntPwrStsUpd
+│       │   └── 0
+│       ├── PortControllerIrqCntRxIdSop
+│       │   └── 1
+│       ├── PortControllerIrqCntRxRdo
+│       │   └── 0
+│       ├── PortControllerIrqCntRxSnkCap
+│       │   └── 0
+│       ├── PortControllerIrqCntRxSrcCap
+│       │   └── 0
+│       ├── PortControllerIrqCntStsUpd
+│       │   └── 2
+│       ├── PortControllerIrqCntUsb2Plg
+│       │   └── 0
+│       ├── PortControllerIrqCntUsb2Wak
+│       │   └── 0
+│       ├── PortControllerIrqCntUvdmEnum
+│       │   └── 1
+│       ├── PortControllerIrqCntUvdmStsUpd
+│       │   └── 3
+│       ├── PortControllerIrqCntldcm
+│       │   └── 0
+│       ├── PortControllerLoserReason
+│       │   └── 0
+│       ├── PortControllerMaxPower
+│       │   └── 29850
+│       ├── PortControllerNEprPDOs
+│       │   └── 0
+│       ├── PortControllerNPDOs
+│       │   └── 4
+│       ├── PortControllerPDst
+│       │   └── 5
+│       ├── PortControllerPortMode
+│       │   └── 2
+│       ├── PortControllerPortPDO
+│       │   ├── 134320424
+│       │   ├── 184618
+│       │   ├── 307399
+│       │   ├── 409749
+│       │   ├── 0
+│       │   ├── 0
+│       │   ├── 0
+│       │   ├── 0
+│       │   ├── 0
+│       │   ├── 0
+│       │   ├── 0
+│       │   ├── 0
+│       │   └── 0
+│       ├── PortControllerPowerState
+│       │   └── 255
+│       ├── PortControllerPwrRoleSwapCount
+│       │   └── 0
+│       ├── PortControllerPwrRoleSwapFailCount
+│       │   └── 0
+│       ├── PortControllerShortDetectCount
+│       │   └── 0
+│       ├── PortControllerSrcTypes
+│       │   └── 3
+│       ├── PortControllerSrdoCount
+│       │   └── 1
+│       ├── PortControllerSrdoRejectCount
+│       │   └── 0
+│       ├── PortControllerSrdoRetryCount
+│       │   └── 0
+│       ├── PortControllerSrdyCount
+│       │   └── 1
+│       ├── PortControllerSrdyRejectCount
+│       │   └── 0
+│       ├── PortControllerStuckCmdCount
+│       │   └── 0
+│       ├── PortControllerSurpriseAckCount
+│       │   └── 0
+│       ├── PortControllerSurpriseNackCount
+│       │   └── 0
+│       ├── PortControllerUvdmStatus
+│       │   └── 3
+│       ├── PortControllerVdoFailCount
+│       │   └── 0
+│       └── PortControllerWakeFailCount
+│           └── 0
+├── PostChargeWaitSeconds
+│   └── 120
+├── PostDischargeWaitSeconds
+│   └── 120
+├── PowerDistribution
+│   ├── IPDChargingAllowed
+│   │   └── 1
+│   ├── IPDInputCurrent
+│   │   └── 1490
+│   ├── IPDInputPower
+│   │   └── 29800
+│   ├── IPDInputVoltage
+│   │   └── 20000
+│   ├── IPDRatioOverride
+│   │   └── 255
+│   └── IPDWattageOverride
+│       └── 30000
+├── PowerTelemetryData
+│   ├── AccumSystemEffectiveTotalLoad
+│   │   └── 0
+│   ├── AccumSystemEffectiveTotalLoadCount
+│   │   └── 0
+│   ├── AccumulatedAdapterEfficiencyLoss
+│   │   └── 454964
+│   ├── AccumulatedBatteryDischarge
+│   │   └── -630
+│   ├── AccumulatedBatteryPower
+│   │   └── 12742993
+│   ├── AccumulatedSystemEnergyConsumed
+│   │   └── 5212399
+│   ├── AccumulatedSystemLoad
+│   │   └── 6023301
+│   ├── AccumulatedSystemPowerIn
+│   │   └── 18765664
+│   ├── AccumulatedWallEnergyEstimate
+│   │   └── 5667363
+│   ├── AdapterEfficiencyLoss
+│   │   └── 684
+│   ├── AdapterEfficiencyLossAccumulatorCount
+│   │   └── 665
+│   ├── BatteryDischargeAccumulatorCount
+│   │   └── 1
+│   ├── BatteryPower
+│   │   └── 23987
+│   ├── BatteryPowerAccumulatorCount
+│   │   └── 665
+│   ├── PowerTelemetryErrorCount
+│   │   └── 0
+│   ├── SystemCurrentIn
+│   │   └── 1412
+│   ├── SystemEffectiveTotalLoad
+│   │   └── 0
+│   ├── SystemEnergyConsumed
+│   │   └── 7838
+│   ├── SystemLoad
+│   │   └── 4230
+│   ├── SystemLoadAccumulatorCount
+│   │   └── 666
+│   ├── SystemPowerIn
+│   │   └── 28217
+│   ├── SystemPowerInAccumulatorCount
+│   │   └── 665
+│   ├── SystemVoltageIn
+│   │   └── 19977
+│   └── WallEnergyEstimate
+│       └── 8522
+├── Serial
+│   └── F8Y2275059S10X2AF
+├── SkipperNEIgnoreAtCritical
+│   └── 0
+├── TimeRemaining
+│   └── 160
+├── UpdateTime
+│   └── 1785304833
+├── UserVisiblePathUpdated
+│   └── 1785304833
+├── Voltage
+│   └── 11842
+└── built-in
+    └── 1

--- a/MeasuredValues/AppleSmartBattery/MacBook_Pro_M1_Pro_macOS_15.txt
+++ b/MeasuredValues/AppleSmartBattery/MacBook_Pro_M1_Pro_macOS_15.txt
@@ -1,0 +1,1090 @@
+.
+├── AbsoluteCapacity
+│   └── 0
+├── AdapterDetails
+│   ├── AdapterID
+│   │   └── 28674
+│   ├── AdapterVoltage
+│   │   └── 20000
+│   ├── Current
+│   │   └── 4690
+│   ├── Description
+│   │   └── pd charger
+│   ├── FamilyCode
+│   │   └── -536854518
+│   ├── FwVersion
+│   │   └── 01080053
+│   ├── HwVersion
+│   │   └── 1.0
+│   ├── IsWireless
+│   │   └── 0
+│   ├── Manufacturer
+│   │   └── Apple Inc.
+│   ├── Model
+│   │   └── 0x7002
+│   ├── Name
+│   │   └── 96W USB-C Power Adapter
+│   ├── PMUConfiguration
+│   │   └── 4460
+│   ├── SerialString
+│   │   └── C4H1514040KPM0WA9
+│   ├── UsbHvcHvcIndex
+│   │   └── 3
+│   ├── UsbHvcMenu
+│   │   ├── .
+│   │   │   ├── Index
+│   │   │   │   └── 0
+│   │   │   ├── MaxCurrent
+│   │   │   │   └── 2960
+│   │   │   └── MaxVoltage
+│   │   │       └── 5000
+│   │   ├── .
+│   │   │   ├── Index
+│   │   │   │   └── 1
+│   │   │   ├── MaxCurrent
+│   │   │   │   └── 2980
+│   │   │   └── MaxVoltage
+│   │   │       └── 9000
+│   │   ├── .
+│   │   │   ├── Index
+│   │   │   │   └── 2
+│   │   │   ├── MaxCurrent
+│   │   │   │   └── 2990
+│   │   │   └── MaxVoltage
+│   │   │       └── 15000
+│   │   └── .
+│   │       ├── Index
+│   │       │   └── 3
+│   │       ├── MaxCurrent
+│   │       │   └── 4690
+│   │       └── MaxVoltage
+│   │           └── 20000
+│   └── Watts
+│       └── 94
+├── AdapterInfo
+│   └── 0
+├── Amperage
+│   └── 5114
+├── AppleRawAdapterDetails
+│   └── .
+│       ├── AdapterID
+│       │   └── 28674
+│       ├── AdapterVoltage
+│       │   └── 20000
+│       ├── Current
+│       │   └── 4690
+│       ├── Description
+│       │   └── pd charger
+│       ├── FamilyCode
+│       │   └── -536854518
+│       ├── FwVersion
+│       │   └── 01080053
+│       ├── HwVersion
+│       │   └── 1.0
+│       ├── IsWireless
+│       │   └── 0
+│       ├── Manufacturer
+│       │   └── Apple Inc.
+│       ├── Model
+│       │   └── 0x7002
+│       ├── Name
+│       │   └── 96W USB-C Power Adapter
+│       ├── PMUConfiguration
+│       │   └── 4460
+│       ├── SerialString
+│       │   └── C4H1514040KPM0WA9
+│       ├── UsbHvcHvcIndex
+│       │   └── 3
+│       ├── UsbHvcMenu
+│       │   ├── .
+│       │   │   ├── Index
+│       │   │   │   └── 0
+│       │   │   ├── MaxCurrent
+│       │   │   │   └── 2960
+│       │   │   └── MaxVoltage
+│       │   │       └── 5000
+│       │   ├── .
+│       │   │   ├── Index
+│       │   │   │   └── 1
+│       │   │   ├── MaxCurrent
+│       │   │   │   └── 2980
+│       │   │   └── MaxVoltage
+│       │   │       └── 9000
+│       │   ├── .
+│       │   │   ├── Index
+│       │   │   │   └── 2
+│       │   │   ├── MaxCurrent
+│       │   │   │   └── 2990
+│       │   │   └── MaxVoltage
+│       │   │       └── 15000
+│       │   └── .
+│       │       ├── Index
+│       │       │   └── 3
+│       │       ├── MaxCurrent
+│       │       │   └── 4690
+│       │       └── MaxVoltage
+│       │           └── 20000
+│       └── Watts
+│           └── 94
+├── AppleRawBatteryVoltage
+│   └── 12532
+├── AppleRawCurrentCapacity
+│   └── 3386
+├── AppleRawExternalConnected
+│   └── 1
+├── AppleRawMaxCapacity
+│   └── 5704
+├── AtCriticalLevel
+│   └── 0
+├── AvgTimeToEmpty
+│   └── 65535
+├── AvgTimeToFull
+│   └── 62
+├── BatteryCellDisconnectCount
+│   └── 0
+├── BatteryData
+│   ├── AdapterPower
+│   │   └── 77.19505
+│   ├── AlgoChemID
+│   │   └── 20882
+│   ├── BatteryHealthMetric
+│   │   └── 0
+│   ├── BatteryState
+│   │   └── {length = 17, bytes = 0x00000000000000000083e4400202000100}
+│   ├── CellCurrentAccumulator
+│   │   ├── 0
+│   │   └── 0
+│   ├── CellCurrentAccumulatorCount
+│   │   └── 0
+│   ├── CellVoltage
+│   │   ├── 4179
+│   │   ├── 4174
+│   │   └── 4178
+│   ├── CellWom
+│   │   ├── 0
+│   │   └── 0
+│   ├── ChargeAccum
+│   │   └── 0
+│   ├── ChemID
+│   │   └── 20882
+│   ├── ChemicalWeightedRa
+│   │   └── 0
+│   ├── CurrentSenseMonitorStatus
+│   │   └── 0
+│   ├── CycleCount
+│   │   └── 39
+│   ├── DOD0
+│   │   ├── 15965
+│   │   ├── 15852
+│   │   └── 15977
+│   ├── DailyMaxSoc
+│   │   └── 53
+│   ├── DailyMinSoc
+│   │   └── 0
+│   ├── DataFlashWriteCount
+│   │   └── 10885
+│   ├── DateOfFirstUse
+│   │   └── 0
+│   ├── DesignCapacity
+│   │   └── 6075
+│   ├── Dod0AtQualifiedQmax
+│   │   └── 0
+│   ├── FccComp1
+│   │   └── 5840
+│   ├── FccComp2
+│   │   └── 5704
+│   ├── FilteredCurrent
+│   │   └── 0
+│   ├── Flags
+│   │   └── 16777216
+│   ├── GaugeFlagRaw
+│   │   └── 128
+│   ├── ISS
+│   │   └── 5045
+│   ├── ITMiscStatus
+│   │   └── 0
+│   ├── LifetimeData
+│   │   ├── AverageTemperature
+│   │   │   └── 286
+│   │   ├── CycleCountLastQmax
+│   │   │   └── 37
+│   │   ├── MaximumChargeCurrent
+│   │   │   └── 6493
+│   │   ├── MaximumDischargeCurrent
+│   │   │   └── -6133
+│   │   ├── MaximumPackVoltage
+│   │   │   └── 12999
+│   │   ├── MaximumTemperature
+│   │   │   └── 42
+│   │   ├── MinimumPackVoltage
+│   │   │   └── 9019
+│   │   ├── MinimumTemperature
+│   │   │   └── 10
+│   │   ├── RDISCnt
+│   │   │   └── 0
+│   │   ├── Raw
+│   │   │   └── {length = 64, bytes = 0x064dcca2 0048df7e 00000000 00000000 ... 011e0007 7f0d0041 }
+│   │   ├── ResistanceUpdatedDisabledCount
+│   │   │   └── 0
+│   │   ├── TemperatureSamples
+│   │   │   └── 491277
+│   │   ├── TimeAtHighSoc
+│   │   │   └── {length = 112, bytes = 0x00000000 c90d0000 b41b0000 f3010000 ... 00000000 00000000 }
+│   │   ├── TotalOperatingTime
+│   │   │   └── 30704
+│   │   └── UpdateTime
+│   │       └── 1785303329
+│   ├── ManufactureDate
+│   │   └── 58489706723634
+│   ├── MaxCapacity
+│   │   └── 100
+│   ├── MfgData
+│   │   └── {length = 32, bytes = 0x00000000 0b000100 48140000 04313931 ... 4c000500 00000000 }
+│   ├── MiscStatus
+│   │   └── 0
+│   ├── PMUConfigured
+│   │   └── 4488
+│   ├── PackCurrentAccumulator
+│   │   └── 12871356
+│   ├── PackCurrentAccumulatorCount
+│   │   └── 2324
+│   ├── PassedCharge
+│   │   └── -3565
+│   ├── PresentDOD
+│   │   ├── 40
+│   │   ├── 39
+│   │   └── 40
+│   ├── Qmax
+│   │   ├── 6192
+│   │   ├── 6238
+│   │   └── 6155
+│   ├── QmaxDisqualificationReason
+│   │   └── 0
+│   ├── Qstart
+│   │   └── 0
+│   ├── RSS
+│   │   └── 0
+│   ├── Ra00
+│   │   └── 218
+│   ├── Ra01
+│   │   └── 58
+│   ├── Ra02
+│   │   └── 75
+│   ├── Ra03
+│   │   └── 98
+│   ├── Ra04
+│   │   └── 92
+│   ├── Ra05
+│   │   └── 59
+│   ├── Ra06
+│   │   └── 79
+│   ├── Ra07
+│   │   └── 70
+│   ├── Ra08
+│   │   └── 78
+│   ├── Ra09
+│   │   └── 83
+│   ├── Ra10
+│   │   └── 89
+│   ├── Ra11
+│   │   └── 104
+│   ├── Ra12
+│   │   └── 178
+│   ├── Ra13
+│   │   └── 422
+│   ├── Ra14
+│   │   └── 703
+│   ├── RaTableRaw
+│   │   ├── {length = 32, bytes = 0x00e2003e 0044005c 005e0037 0048004b ... 00c101d3 03040000 }
+│   │   ├── {length = 32, bytes = 0x00d80036 0048005f 0063003e 00540049 ... 00bf01ca 03000000 }
+│   │   └── {length = 32, bytes = 0x00da003a 004b0062 005c003b 004f0046 ... 00b201a6 02bf0000 }
+│   ├── ResScale
+│   │   └── 0
+│   ├── Serial
+│   │   └── F8Y152505GYQ1LTA9
+│   ├── SimRate
+│   │   └── 0
+│   ├── Soc1Voltage
+│   │   └── 0
+│   ├── StateOfCharge
+│   │   └── 59
+│   ├── SystemPower
+│   │   └── 17.94236
+│   ├── TrueRemainingCapacity
+│   │   └── 0
+│   ├── Voltage
+│   │   └── 12531
+│   ├── WeightedRa
+│   │   ├── 84
+│   │   ├── 86
+│   │   └── 86
+│   └── iMaxAndSocSmoothTable
+│       └── {length = 32, bytes = 0x00000000 00000000 00000000 00000000 ... 00000000 00000000 }
+├── BatteryInstalled
+│   └── 1
+├── BatteryInvalidWakeSeconds
+│   └── 30
+├── BestAdapterIndex
+│   └── 0
+├── BootPathUpdated
+│   └── 1785301194
+├── BootVoltage
+│   └── 0
+├── CarrierMode
+│   ├── CarrierModeHighVoltage
+│   │   └── 4100
+│   ├── CarrierModeLowVoltage
+│   │   └── 3600
+│   └── CarrierModeStatus
+│       └── 0
+├── ChargerConfiguration
+│   └── 4488
+├── ChargerData
+│   ├── ChargerID
+│   │   └── 12
+│   ├── ChargerInhibitReason
+│   │   └── 0
+│   ├── ChargerResetCounter
+│   │   └── 0
+│   ├── ChargerStatus
+│   │   └── {length = 64, bytes = 0x06008ad8 c4089840 00000000 00000000 ... 00000000 00000000 }
+│   ├── ChargingCurrent
+│   │   └── 5036
+│   ├── ChargingVoltage
+│   │   └── 4268
+│   ├── NotChargingReason
+│   │   └── 0
+│   ├── SlowChargingReason
+│   │   └── 0
+│   ├── TimeChargingThermallyLimited
+│   │   └── 0
+│   └── VacVoltageLimit
+│       └── 4308
+├── CurrentCapacity
+│   └── 59
+├── CycleCount
+│   └── 39
+├── DesignCapacity
+│   └── 6075
+├── DesignCycleCount9C
+│   └── 1000
+├── DeviceName
+│   └── bq40z651
+├── ExternalChargeCapable
+│   └── 1
+├── ExternalConnected
+│   └── 1
+├── FedDetails
+│   ├── .
+│   │   ├── FedDesignCapacity
+│   │   │   └── 0
+│   │   ├── FedDualRolePower
+│   │   │   └── 0
+│   │   ├── FedExternalConnected
+│   │   │   └── 0
+│   │   ├── FedPdSpecRevision
+│   │   │   └── 0
+│   │   ├── FedPortPowerRole
+│   │   │   └── 0
+│   │   ├── FedProductID
+│   │   │   └── 0
+│   │   ├── FedPwrPolicySt
+│   │   │   └── 0
+│   │   ├── FedRemainingCapacity
+│   │   │   └── 0
+│   │   ├── FedSnkConfReason
+│   │   │   └── 0
+│   │   ├── FedSrcConfReason
+│   │   │   └── 0
+│   │   ├── FedStateOfCharge
+│   │   │   └── 0
+│   │   └── FedVendorID
+│   │       └── 0
+│   ├── .
+│   │   ├── FedDesignCapacity
+│   │   │   └── 0
+│   │   ├── FedDualRolePower
+│   │   │   └── 0
+│   │   ├── FedExternalConnected
+│   │   │   └── 0
+│   │   ├── FedPdSpecRevision
+│   │   │   └── 0
+│   │   ├── FedPortPowerRole
+│   │   │   └── 0
+│   │   ├── FedProductID
+│   │   │   └── 0
+│   │   ├── FedPwrPolicySt
+│   │   │   └── 0
+│   │   ├── FedRemainingCapacity
+│   │   │   └── 0
+│   │   ├── FedSnkConfReason
+│   │   │   └── 0
+│   │   ├── FedSrcConfReason
+│   │   │   └── 0
+│   │   ├── FedStateOfCharge
+│   │   │   └── 0
+│   │   └── FedVendorID
+│   │       └── 0
+│   ├── .
+│   │   ├── FedDesignCapacity
+│   │   │   └── 0
+│   │   ├── FedDualRolePower
+│   │   │   └── 0
+│   │   ├── FedExternalConnected
+│   │   │   └── 0
+│   │   ├── FedPdSpecRevision
+│   │   │   └── 0
+│   │   ├── FedPortPowerRole
+│   │   │   └── 0
+│   │   ├── FedProductID
+│   │   │   └── 0
+│   │   ├── FedPwrPolicySt
+│   │   │   └── 0
+│   │   ├── FedRemainingCapacity
+│   │   │   └── 0
+│   │   ├── FedSnkConfReason
+│   │   │   └── 0
+│   │   ├── FedSrcConfReason
+│   │   │   └── 0
+│   │   ├── FedStateOfCharge
+│   │   │   └── 0
+│   │   └── FedVendorID
+│   │       └── 0
+│   └── .
+│       ├── FedDesignCapacity
+│       │   └── 0
+│       ├── FedDualRolePower
+│       │   └── 0
+│       ├── FedExternalConnected
+│       │   └── 1
+│       ├── FedPdSpecRevision
+│       │   └── 1
+│       ├── FedPortPowerRole
+│       │   └── 0
+│       ├── FedProductID
+│       │   └── 0
+│       ├── FedPwrPolicySt
+│       │   └── 0
+│       ├── FedRemainingCapacity
+│       │   └── 0
+│       ├── FedSnkConfReason
+│       │   └── 0
+│       ├── FedSrcConfReason
+│       │   └── 0
+│       ├── FedStateOfCharge
+│       │   └── 0
+│       └── FedVendorID
+│           └── 0
+├── FullPathUpdated
+│   └── 1785303089
+├── FullyCharged
+│   └── 0
+├── GasGaugeFirmwareVersion
+│   └── 2
+├── IOGeneralInterest
+│   └── IOCommand is not serializable
+├── IOReportLegend
+│   └── .
+│       ├── IOReportChannelInfo
+│       │   └── IOReportChannelUnit
+│       │       └── 0
+│       ├── IOReportChannels
+│       │   └── .
+│       │       ├── 7167869599145487988
+│       │       ├── 6460407809
+│       │       └── BatteryCycleCount
+│       └── IOReportGroupName
+│           └── Battery
+├── IOReportLegendPublic
+│   └── 1
+├── InstantAmperage
+│   └── 5114
+├── IsCharging
+│   └── 1
+├── KioskMode
+│   ├── KioskModeFullChargeVoltage
+│   │   └── 0
+│   ├── KioskModeHighSocDays
+│   │   └── 0
+│   ├── KioskModeHighSocSeconds
+│   │   └── 0
+│   ├── KioskModeLastHighSocHours
+│   │   └── 0
+│   └── KioskModeMode
+│       └── 0
+├── Location
+│   └── 0
+├── ManufacturerData
+│   └── {length = 32, bytes = 0x00000000 0b000100 48140000 04313931 ... 4c000500 00000000 }
+├── MaxCapacity
+│   └── 100
+├── NominalChargeCapacity
+│   └── 5854
+├── PackReserve
+│   └── 150
+├── PermanentFailureStatus
+│   └── 0
+├── PortControllerInfo
+│   ├── .
+│   │   ├── PortControllerActiveContractRdo
+│   │   │   └── 0
+│   │   ├── PortControllerAttachCount
+│   │   │   └── 0
+│   │   ├── PortControllerBootFlags
+│   │   │   └── 0
+│   │   ├── PortControllerCapMismatch
+│   │   │   └── 0
+│   │   ├── PortControllerDataRoleSwapCount
+│   │   │   └── 0
+│   │   ├── PortControllerDataRoleSwapFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerDetachCount
+│   │   │   └── 0
+│   │   ├── PortControllerDnSt
+│   │   │   └── 0
+│   │   ├── PortControllerElectionFailReason
+│   │   │   └── 0
+│   │   ├── PortControllerEvtBuffer
+│   │   │   └── {length = 120, bytes = 0x00000000 00000000 00000000 00000000 ... 00000000 00000000 }
+│   │   ├── PortControllerFetStatus
+│   │   │   └── 0
+│   │   ├── PortControllerFwVersion
+│   │   │   └── 2191360
+│   │   ├── PortControllerHardResetCount
+│   │   │   └── 0
+│   │   ├── PortControllerHvEnRecoveryCount
+│   │   │   └── 0
+│   │   ├── PortControllerI2cErrCount
+│   │   │   └── 0
+│   │   ├── PortControllerInpFetEnFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntAlert
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntAppLd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntConSrc
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntHrdRst
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPdStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPlg
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPwrStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxIdSop
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxRdo
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxSnkCap
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxSrcCap
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUsb2Plg
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUsb2Wak
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUvdmEnum
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUvdmStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntldcm
+│   │   │   └── 0
+│   │   ├── PortControllerLoserReason
+│   │   │   └── 1
+│   │   ├── PortControllerMaxPower
+│   │   │   └── 0
+│   │   ├── PortControllerNEprPDOs
+│   │   │   └── 0
+│   │   ├── PortControllerNPDOs
+│   │   │   └── 0
+│   │   ├── PortControllerPDst
+│   │   │   └── 0
+│   │   ├── PortControllerPortMode
+│   │   │   └── 2
+│   │   ├── PortControllerPortPDO
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   └── 0
+│   │   ├── PortControllerPowerState
+│   │   │   └── 255
+│   │   ├── PortControllerPwrRoleSwapCount
+│   │   │   └── 0
+│   │   ├── PortControllerPwrRoleSwapFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerShortDetectCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrcTypes
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoRejectCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoRetryCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdyCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdyRejectCount
+│   │   │   └── 0
+│   │   ├── PortControllerStuckCmdCount
+│   │   │   └── 0
+│   │   ├── PortControllerSurpriseAckCount
+│   │   │   └── 0
+│   │   ├── PortControllerSurpriseNackCount
+│   │   │   └── 0
+│   │   ├── PortControllerUvdmStatus
+│   │   │   └── 0
+│   │   ├── PortControllerVdoFailCount
+│   │   │   └── 0
+│   │   └── PortControllerWakeFailCount
+│   │       └── 0
+│   ├── .
+│   │   ├── PortControllerActiveContractRdo
+│   │   │   └── 0
+│   │   ├── PortControllerAttachCount
+│   │   │   └── 0
+│   │   ├── PortControllerBootFlags
+│   │   │   └── 0
+│   │   ├── PortControllerCapMismatch
+│   │   │   └── 0
+│   │   ├── PortControllerDataRoleSwapCount
+│   │   │   └── 0
+│   │   ├── PortControllerDataRoleSwapFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerDetachCount
+│   │   │   └── 0
+│   │   ├── PortControllerDnSt
+│   │   │   └── 0
+│   │   ├── PortControllerElectionFailReason
+│   │   │   └── 0
+│   │   ├── PortControllerEvtBuffer
+│   │   │   └── {length = 120, bytes = 0x00000000 00000000 00000000 00000000 ... 00000000 00000000 }
+│   │   ├── PortControllerFetStatus
+│   │   │   └── 0
+│   │   ├── PortControllerFwVersion
+│   │   │   └── 2191360
+│   │   ├── PortControllerHardResetCount
+│   │   │   └── 0
+│   │   ├── PortControllerHvEnRecoveryCount
+│   │   │   └── 0
+│   │   ├── PortControllerI2cErrCount
+│   │   │   └── 0
+│   │   ├── PortControllerInpFetEnFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntAlert
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntAppLd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntConSrc
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntHrdRst
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPdStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPlg
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPwrStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxIdSop
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxRdo
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxSnkCap
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxSrcCap
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUsb2Plg
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUsb2Wak
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUvdmEnum
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUvdmStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntldcm
+│   │   │   └── 0
+│   │   ├── PortControllerLoserReason
+│   │   │   └── 1
+│   │   ├── PortControllerMaxPower
+│   │   │   └── 0
+│   │   ├── PortControllerNEprPDOs
+│   │   │   └── 0
+│   │   ├── PortControllerNPDOs
+│   │   │   └── 0
+│   │   ├── PortControllerPDst
+│   │   │   └── 0
+│   │   ├── PortControllerPortMode
+│   │   │   └── 2
+│   │   ├── PortControllerPortPDO
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   └── 0
+│   │   ├── PortControllerPowerState
+│   │   │   └── 255
+│   │   ├── PortControllerPwrRoleSwapCount
+│   │   │   └── 0
+│   │   ├── PortControllerPwrRoleSwapFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerShortDetectCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrcTypes
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoRejectCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoRetryCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdyCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdyRejectCount
+│   │   │   └── 0
+│   │   ├── PortControllerStuckCmdCount
+│   │   │   └── 0
+│   │   ├── PortControllerSurpriseAckCount
+│   │   │   └── 0
+│   │   ├── PortControllerSurpriseNackCount
+│   │   │   └── 0
+│   │   ├── PortControllerUvdmStatus
+│   │   │   └── 0
+│   │   ├── PortControllerVdoFailCount
+│   │   │   └── 0
+│   │   └── PortControllerWakeFailCount
+│   │       └── 0
+│   ├── .
+│   │   ├── PortControllerActiveContractRdo
+│   │   │   └── 0
+│   │   ├── PortControllerAttachCount
+│   │   │   └── 0
+│   │   ├── PortControllerBootFlags
+│   │   │   └── 0
+│   │   ├── PortControllerCapMismatch
+│   │   │   └── 0
+│   │   ├── PortControllerDataRoleSwapCount
+│   │   │   └── 0
+│   │   ├── PortControllerDataRoleSwapFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerDetachCount
+│   │   │   └── 0
+│   │   ├── PortControllerDnSt
+│   │   │   └── 0
+│   │   ├── PortControllerElectionFailReason
+│   │   │   └── 0
+│   │   ├── PortControllerEvtBuffer
+│   │   │   └── {length = 120, bytes = 0x00000000 00000000 00000000 00000000 ... 00000000 00000000 }
+│   │   ├── PortControllerFetStatus
+│   │   │   └── 0
+│   │   ├── PortControllerFwVersion
+│   │   │   └── 2191360
+│   │   ├── PortControllerHardResetCount
+│   │   │   └── 0
+│   │   ├── PortControllerHvEnRecoveryCount
+│   │   │   └── 0
+│   │   ├── PortControllerI2cErrCount
+│   │   │   └── 0
+│   │   ├── PortControllerInpFetEnFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntAlert
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntAppLd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntConSrc
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntHrdRst
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPdStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPlg
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPwrStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxIdSop
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxRdo
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxSnkCap
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxSrcCap
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUsb2Plg
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUsb2Wak
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUvdmEnum
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUvdmStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntldcm
+│   │   │   └── 0
+│   │   ├── PortControllerLoserReason
+│   │   │   └── 1
+│   │   ├── PortControllerMaxPower
+│   │   │   └── 0
+│   │   ├── PortControllerNEprPDOs
+│   │   │   └── 0
+│   │   ├── PortControllerNPDOs
+│   │   │   └── 0
+│   │   ├── PortControllerPDst
+│   │   │   └── 0
+│   │   ├── PortControllerPortMode
+│   │   │   └── 2
+│   │   ├── PortControllerPortPDO
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   └── 0
+│   │   ├── PortControllerPowerState
+│   │   │   └── 255
+│   │   ├── PortControllerPwrRoleSwapCount
+│   │   │   └── 0
+│   │   ├── PortControllerPwrRoleSwapFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerShortDetectCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrcTypes
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoRejectCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoRetryCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdyCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdyRejectCount
+│   │   │   └── 0
+│   │   ├── PortControllerStuckCmdCount
+│   │   │   └── 0
+│   │   ├── PortControllerSurpriseAckCount
+│   │   │   └── 0
+│   │   ├── PortControllerSurpriseNackCount
+│   │   │   └── 0
+│   │   ├── PortControllerUvdmStatus
+│   │   │   └── 0
+│   │   ├── PortControllerVdoFailCount
+│   │   │   └── 0
+│   │   └── PortControllerWakeFailCount
+│   │       └── 0
+│   └── .
+│       ├── PortControllerActiveContractRdo
+│       │   └── 1090999765
+│       ├── PortControllerAttachCount
+│       │   └── 0
+│       ├── PortControllerBootFlags
+│       │   └── 0
+│       ├── PortControllerCapMismatch
+│       │   └── 0
+│       ├── PortControllerDataRoleSwapCount
+│       │   └── 0
+│       ├── PortControllerDataRoleSwapFailCount
+│       │   └── 0
+│       ├── PortControllerDetachCount
+│       │   └── 0
+│       ├── PortControllerDnSt
+│       │   └── 17
+│       ├── PortControllerElectionFailReason
+│       │   └── 0
+│       ├── PortControllerEvtBuffer
+│       │   └── {length = 120, bytes = 0x00000000 00000000 00000000 00000000 ... 305f485f 5f5e015f }
+│       ├── PortControllerFetStatus
+│       │   └── 140
+│       ├── PortControllerFwVersion
+│       │   └── 2191360
+│       ├── PortControllerHardResetCount
+│       │   └── 0
+│       ├── PortControllerHvEnRecoveryCount
+│       │   └── 0
+│       ├── PortControllerI2cErrCount
+│       │   └── 0
+│       ├── PortControllerInpFetEnFailCount
+│       │   └── 0
+│       ├── PortControllerIrqCntAlert
+│       │   └── 0
+│       ├── PortControllerIrqCntAppLd
+│       │   └── 0
+│       ├── PortControllerIrqCntConSrc
+│       │   └── 0
+│       ├── PortControllerIrqCntHrdRst
+│       │   └── 0
+│       ├── PortControllerIrqCntPdStsUpd
+│       │   └── 1
+│       ├── PortControllerIrqCntPlg
+│       │   └── 0
+│       ├── PortControllerIrqCntPwrStsUpd
+│       │   └── 0
+│       ├── PortControllerIrqCntRxIdSop
+│       │   └── 1
+│       ├── PortControllerIrqCntRxRdo
+│       │   └── 0
+│       ├── PortControllerIrqCntRxSnkCap
+│       │   └── 0
+│       ├── PortControllerIrqCntRxSrcCap
+│       │   └── 0
+│       ├── PortControllerIrqCntStsUpd
+│       │   └── 2
+│       ├── PortControllerIrqCntUsb2Plg
+│       │   └── 0
+│       ├── PortControllerIrqCntUsb2Wak
+│       │   └── 0
+│       ├── PortControllerIrqCntUvdmEnum
+│       │   └── 1
+│       ├── PortControllerIrqCntUvdmStsUpd
+│       │   └── 4
+│       ├── PortControllerIrqCntldcm
+│       │   └── 0
+│       ├── PortControllerLoserReason
+│       │   └── 0
+│       ├── PortControllerMaxPower
+│       │   └── 93800
+│       ├── PortControllerNEprPDOs
+│       │   └── 0
+│       ├── PortControllerNPDOs
+│       │   └── 4
+│       ├── PortControllerPDst
+│       │   └── 5
+│       ├── PortControllerPortMode
+│       │   └── 2
+│       ├── PortControllerPortPDO
+│       │   ├── 134320424
+│       │   ├── 184618
+│       │   ├── 307499
+│       │   ├── 410069
+│       │   ├── 0
+│       │   ├── 0
+│       │   ├── 0
+│       │   ├── 0
+│       │   ├── 0
+│       │   ├── 0
+│       │   ├── 0
+│       │   ├── 0
+│       │   └── 0
+│       ├── PortControllerPowerState
+│       │   └── 255
+│       ├── PortControllerPwrRoleSwapCount
+│       │   └── 0
+│       ├── PortControllerPwrRoleSwapFailCount
+│       │   └── 0
+│       ├── PortControllerShortDetectCount
+│       │   └── 0
+│       ├── PortControllerSrcTypes
+│       │   └── 3
+│       ├── PortControllerSrdoCount
+│       │   └── 1
+│       ├── PortControllerSrdoRejectCount
+│       │   └── 0
+│       ├── PortControllerSrdoRetryCount
+│       │   └── 0
+│       ├── PortControllerSrdyCount
+│       │   └── 1
+│       ├── PortControllerSrdyRejectCount
+│       │   └── 0
+│       ├── PortControllerStuckCmdCount
+│       │   └── 0
+│       ├── PortControllerSurpriseAckCount
+│       │   └── 0
+│       ├── PortControllerSurpriseNackCount
+│       │   └── 0
+│       ├── PortControllerUvdmStatus
+│       │   └── 3
+│       ├── PortControllerVdoFailCount
+│       │   └── 0
+│       └── PortControllerWakeFailCount
+│           └── 0
+├── PostChargeWaitSeconds
+│   └── 120
+├── PostDischargeWaitSeconds
+│   └── 120
+├── PowerTelemetryData
+│   ├── AccumulatedAdapterEfficiencyLoss
+│   │   └── 4300233078
+│   ├── AccumulatedBatteryDischarge
+│   │   └── -3838476
+│   ├── AccumulatedBatteryPower
+│   │   └── 8690810
+│   ├── AccumulatedSystemEnergyConsumed
+│   │   └── 48631141
+│   ├── AccumulatedSystemLoad
+│   │   └── 170223319
+│   ├── AccumulatedSystemPowerIn
+│   │   └── 175075653
+│   ├── AccumulatedWallEnergyEstimate
+│   │   └── 53896923
+│   ├── AdapterEfficiencyLoss
+│   │   └── 2416
+│   ├── AdapterEfficiencyLossAccumulatorCount
+│   │   └── 2133
+│   ├── BatteryDischargeAccumulatorCount
+│   │   └── 558
+│   ├── BatteryPower
+│   │   └── -1448
+│   ├── BatteryPowerAccumulatorCount
+│   │   └── 1576
+│   ├── PowerTelemetryErrorCount
+│   │   └── 0
+│   ├── SystemCurrentIn
+│   │   └── 4078
+│   ├── SystemEnergyConsumed
+│   │   └── 22365
+│   ├── SystemLoad
+│   │   └── 81964
+│   ├── SystemLoadAccumulatorCount
+│   │   └── 2134
+│   ├── SystemPowerIn
+│   │   └── 80516
+│   ├── SystemPowerInAccumulatorCount
+│   │   └── 2133
+│   ├── SystemVoltageIn
+│   │   └── 19744
+│   └── WallEnergyEstimate
+│       └── 24781
+├── Serial
+│   └── F8Y152505GYQ1LTA9
+├── Temperature
+│   └── 3115
+├── TimeRemaining
+│   └── 62
+├── UpdateTime
+│   └── 1785303329
+├── UserVisiblePathUpdated
+│   └── 1785303329
+├── VirtualTemperature
+│   └── 3829
+├── Voltage
+│   └── 12532
+└── built-in
+    └── 1

--- a/MeasuredValues/AppleSmartBattery/MacBook_Pro_M4_Pro_macOS_26.txt
+++ b/MeasuredValues/AppleSmartBattery/MacBook_Pro_M4_Pro_macOS_26.txt
@@ -1,0 +1,1247 @@
+.
+├── AbsoluteCapacity
+│   └── 0
+├── AdapterDetails
+│   ├── AdapterID
+│   │   └── 0
+│   ├── AdapterPowerTier
+│   │   └── 2
+│   ├── AdapterVoltage
+│   │   └── 20000
+│   ├── Current
+│   │   └── 4500
+│   ├── Description
+│   │   └── pd charger
+│   ├── FamilyCode
+│   │   └── -536854518
+│   ├── IsWireless
+│   │   └── 0
+│   ├── PMUConfiguration
+│   │   └── 4460
+│   ├── UsbHvcHvcIndex
+│   │   └── 3
+│   ├── UsbHvcMenu
+│   │   ├── .
+│   │   │   ├── Index
+│   │   │   │   └── 0
+│   │   │   ├── MaxCurrent
+│   │   │   │   └── 3000
+│   │   │   └── MaxVoltage
+│   │   │       └── 5000
+│   │   ├── .
+│   │   │   ├── Index
+│   │   │   │   └── 1
+│   │   │   ├── MaxCurrent
+│   │   │   │   └── 3000
+│   │   │   └── MaxVoltage
+│   │   │       └── 9000
+│   │   ├── .
+│   │   │   ├── Index
+│   │   │   │   └── 2
+│   │   │   ├── MaxCurrent
+│   │   │   │   └── 3000
+│   │   │   └── MaxVoltage
+│   │   │       └── 15000
+│   │   └── .
+│   │       ├── Index
+│   │       │   └── 3
+│   │       ├── MaxCurrent
+│   │       │   └── 4500
+│   │       └── MaxVoltage
+│   │           └── 20000
+│   └── Watts
+│       └── 90
+├── AdapterInfo
+│   └── 0
+├── Amperage
+│   └── 0
+├── AppleRawAdapterDetails
+│   └── .
+│       ├── AdapterID
+│       │   └── 0
+│       ├── AdapterPowerTier
+│       │   └── 2
+│       ├── AdapterVoltage
+│       │   └── 20000
+│       ├── Current
+│       │   └── 4500
+│       ├── Description
+│       │   └── pd charger
+│       ├── FamilyCode
+│       │   └── -536854518
+│       ├── IsWireless
+│       │   └── 0
+│       ├── PMUConfiguration
+│       │   └── 4460
+│       ├── UsbHvcHvcIndex
+│       │   └── 3
+│       ├── UsbHvcMenu
+│       │   ├── .
+│       │   │   ├── Index
+│       │   │   │   └── 0
+│       │   │   ├── MaxCurrent
+│       │   │   │   └── 3000
+│       │   │   └── MaxVoltage
+│       │   │       └── 5000
+│       │   ├── .
+│       │   │   ├── Index
+│       │   │   │   └── 1
+│       │   │   ├── MaxCurrent
+│       │   │   │   └── 3000
+│       │   │   └── MaxVoltage
+│       │   │       └── 9000
+│       │   ├── .
+│       │   │   ├── Index
+│       │   │   │   └── 2
+│       │   │   ├── MaxCurrent
+│       │   │   │   └── 3000
+│       │   │   └── MaxVoltage
+│       │   │       └── 15000
+│       │   └── .
+│       │       ├── Index
+│       │       │   └── 3
+│       │       ├── MaxCurrent
+│       │       │   └── 4500
+│       │       └── MaxVoltage
+│       │           └── 20000
+│       └── Watts
+│           └── 90
+├── AppleRawBatteryVoltage
+│   └── 12817
+├── AppleRawCurrentCapacity
+│   └── 5660
+├── AppleRawExternalConnected
+│   └── 1
+├── AppleRawMaxCapacity
+│   └── 5797
+├── AtCriticalLevel
+│   └── 0
+├── AvgTimeToEmpty
+│   └── 65535
+├── AvgTimeToFull
+│   └── 65535
+├── BatteryCellDisconnectCount
+│   └── 0
+├── BatteryData
+│   ├── AdapterPower
+│   │   └── 13.29163
+│   ├── AlgoChemID
+│   │   └── 29795
+│   ├── BatteryHealthMetric
+│   │   └── 0
+│   ├── BatteryState
+│   │   └── {length = 17, bytes = 0x000000000000000000c3e40012c4020102}
+│   ├── CellCurrentAccumulator
+│   │   ├── 0
+│   │   └── 0
+│   ├── CellCurrentAccumulatorCount
+│   │   └── 0
+│   ├── CellVoltage
+│   │   ├── 4272
+│   │   ├── 4272
+│   │   └── 4272
+│   ├── CellWom
+│   │   ├── 0
+│   │   └── 0
+│   ├── ChargeAccum
+│   │   └── 0
+│   ├── ChemID
+│   │   └── 29795
+│   ├── ChemicalWeightedRa
+│   │   └── 0
+│   ├── CurrentSenseMonitorStatus
+│   │   └── 0
+│   ├── CycleCount
+│   │   └── 19
+│   ├── DOD0
+│   │   ├── 2000
+│   │   ├── 2000
+│   │   └── 2000
+│   ├── DailyMaxSoc
+│   │   └── 98
+│   ├── DailyMinSoc
+│   │   └── 98
+│   ├── DataFlashWriteCount
+│   │   └── 6281
+│   ├── DateOfFirstUse
+│   │   └── 0
+│   ├── DesignCapacity
+│   │   └── 6249
+│   ├── Dod0AtQualifiedQmax
+│   │   └── 0
+│   ├── FccComp1
+│   │   └── 6369
+│   ├── FccComp2
+│   │   └── 5797
+│   ├── FilteredCurrent
+│   │   └── 0
+│   ├── Flags
+│   │   └── 16777729
+│   ├── GaugeFlagRaw
+│   │   └── 224
+│   ├── ISS
+│   │   └── 0
+│   ├── ITMiscStatus
+│   │   └── 0
+│   ├── IdealCRate
+│   │   └── 0.45
+│   ├── LifetimeData
+│   │   ├── AverageTemperature
+│   │   │   └── 272
+│   │   ├── CycleCountLastQmax
+│   │   │   └── 11
+│   │   ├── MaximumChargeCurrent
+│   │   │   └── 6707
+│   │   ├── MaximumDischargeCurrent
+│   │   │   └── -8026
+│   │   ├── MaximumPackVoltage
+│   │   │   └── 13304
+│   │   ├── MaximumTemperature
+│   │   │   └── 41
+│   │   ├── MinimumPackVoltage
+│   │   │   └── 10839
+│   │   ├── MinimumTemperature
+│   │   │   └── 8
+│   │   ├── RDISCnt
+│   │   │   └── 0
+│   │   ├── Raw
+│   │   │   └── {length = 64, bytes = 0x03307fa3 000539ed 00000000 00000000 ... 01100003 a6f10004 }
+│   │   ├── ResistanceUpdatedDisabledCount
+│   │   │   └── 0
+│   │   ├── TemperatureSamples
+│   │   │   └── 239345
+│   │   ├── TimeAtHighSoc
+│   │   │   └── {length = 112, bytes = 0x00000000 5e090000 fe0f0000 30000000 ... 00000000 00000000 }
+│   │   ├── TotalOperatingTime
+│   │   │   └── 14959
+│   │   └── UpdateTime
+│   │       └── 1785301354
+│   ├── ManufactureDate
+│   │   └── 59580611637811
+│   ├── MaxCapacity
+│   │   └── 100
+│   ├── MfgData
+│   │   └── {length = 32, bytes = 0x00000000 0b000100 271d0000 04333531 ... 4c000000 00000000 }
+│   ├── MiscStatus
+│   │   └── 196
+│   ├── PMUConfigured
+│   │   └── 4440
+│   ├── PackCurrentAccumulator
+│   │   └── 1204612
+│   ├── PackCurrentAccumulatorCount
+│   │   └── 2064831
+│   ├── PassedCharge
+│   │   └── -1
+│   ├── PresentDOD
+│   │   ├── 12
+│   │   ├── 12
+│   │   └── 12
+│   ├── Qmax
+│   │   ├── 6740
+│   │   ├── 6724
+│   │   └── 6733
+│   ├── QmaxDisqualificationReason
+│   │   └── 0
+│   ├── Qstart
+│   │   └── 0
+│   ├── RSS
+│   │   └── 0
+│   ├── Ra00
+│   │   └── 241
+│   ├── Ra01
+│   │   └── 43
+│   ├── Ra02
+│   │   └── 47
+│   ├── Ra03
+│   │   └── 58
+│   ├── Ra04
+│   │   └── 94
+│   ├── Ra05
+│   │   └── 72
+│   ├── Ra06
+│   │   └── 87
+│   ├── Ra07
+│   │   └── 73
+│   ├── Ra08
+│   │   └── 73
+│   ├── Ra09
+│   │   └── 87
+│   ├── Ra10
+│   │   └── 87
+│   ├── Ra11
+│   │   └── 89
+│   ├── Ra12
+│   │   └── 141
+│   ├── Ra13
+│   │   └── 351
+│   ├── Ra14
+│   │   └── 575
+│   ├── RaTableRaw
+│   │   ├── {length = 32, bytes = 0x0109002e 0032003f 0064004d 005b0059 ... 00a60195 02a90000 }
+│   │   ├── {length = 32, bytes = 0x0100002d 00320037 00570041 00480048 ... 008b016e 02470000 }
+│   │   └── {length = 32, bytes = 0x00f1002b 002f003a 005e0048 00570049 ... 008d015f 023f0000 }
+│   ├── ResScale
+│   │   └── 0
+│   ├── Serial
+│   │   └── F8YHB6006DC0000FWK
+│   ├── SimRate
+│   │   └── 0
+│   ├── Soc1Voltage
+│   │   └── 0
+│   ├── StateOfCharge
+│   │   └── 98
+│   ├── SystemPower
+│   │   └── 4.815584
+│   ├── TrueRemainingCapacity
+│   │   └── 0
+│   ├── Voltage
+│   │   └── 12817
+│   ├── WeightedRa
+│   │   ├── 86
+│   │   ├── 76
+│   │   └── 79
+│   └── iMaxAndSocSmoothTable
+│       └── {length = 32, bytes = 0x00000000 00000000 00000000 00000000 ... 00000000 00000000 }
+├── BatteryInstalled
+│   └── 1
+├── BatteryInvalidWakeSeconds
+│   └── 30
+├── BestAdapterIndex
+│   └── 0
+├── BootPathUpdated
+│   └── 1783236652
+├── BootVoltage
+│   └── 0
+├── CarrierMode
+│   ├── CarrierModeHighVoltage
+│   │   └── 4100
+│   ├── CarrierModeLowVoltage
+│   │   └── 3600
+│   └── CarrierModeStatus
+│       └── 0
+├── ChargerConfiguration
+│   └── 4440
+├── ChargerData
+│   ├── ChargerID
+│   │   └── 14
+│   ├── ChargerInhibitReason
+│   │   └── 0
+│   ├── ChargerResetCounter
+│   │   └── 0
+│   ├── ChargerStatus
+│   │   └── {length = 64, bytes = 0x07008ab8 ac089820 444f0000 00000000 ... 00000000 00000000 }
+│   ├── ChargingCurrent
+│   │   └── 0
+│   ├── ChargingVoltage
+│   │   └── 4322
+│   ├── NotChargingReason
+│   │   └── 4194305
+│   ├── SlowChargingReason
+│   │   └── 0
+│   ├── TimeChargingThermallyLimited
+│   │   └── 0
+│   └── VacVoltageLimit
+│       └── 4325
+├── CurrentCapacity
+│   └── 100
+├── CycleCount
+│   └── 19
+├── DeadBatteryBootData
+│   ├── ActivePayloads
+│   │   └── 3
+│   ├── GeneralPayload
+│   │   ├── AdapterType
+│   │   │   └── 0
+│   │   ├── AverageBattSkinTemp
+│   │   │   └── 32
+│   │   ├── AverageBattVirtualTemp
+│   │   │   └── 32
+│   │   ├── CloakEntryCount
+│   │   │   └── 0
+│   │   ├── PrechargeCount
+│   │   │   └── 0
+│   │   ├── StartBatteryCapacity
+│   │   │   └── 0
+│   │   ├── StartBatteryVoltage
+│   │   │   └── 505
+│   │   ├── TimeOnCharger
+│   │   │   └── 6
+│   │   ├── VbusType
+│   │   │   └── 0
+│   │   └── WirelessChargingMode
+│   │       └── 0
+│   └── SMCBootManagementPayload
+│       ├── APBootCount
+│       │   └── 1
+│       ├── AdapterPower
+│       │   └── 0
+│       ├── DeviceResetCount
+│       │   └── 1
+│       ├── DisplayTimeBootCount
+│       │   └── 0
+│       ├── HighPoweriBootCount
+│       │   └── 1
+│       └── Ok2SwitchCount
+│           └── 1
+├── DesignCapacity
+│   └── 6249
+├── DesignCycleCount9C
+│   └── 1000
+├── DeviceName
+│   └── bq40z651
+├── ExternalChargeCapable
+│   └── 1
+├── ExternalConnected
+│   └── 1
+├── FedDetails
+│   ├── .
+│   │   ├── FedDesignCapacity
+│   │   │   └── 280
+│   │   ├── FedDualRolePower
+│   │   │   └── 1
+│   │   ├── FedExternalConnected
+│   │   │   └── 0
+│   │   ├── FedPdSpecRevision
+│   │   │   └── 2
+│   │   ├── FedPortPowerRole
+│   │   │   └── 1
+│   │   ├── FedProductID
+│   │   │   └── 28946
+│   │   ├── FedPwrPolicySt
+│   │   │   └── 0
+│   │   ├── FedRemainingCapacity
+│   │   │   └── 280
+│   │   ├── FedSnkConfReason
+│   │   │   └── 0
+│   │   ├── FedSrcConfReason
+│   │   │   └── 0
+│   │   ├── FedStateOfCharge
+│   │   │   └── 100
+│   │   └── FedVendorID
+│   │       └── 1452
+│   ├── .
+│   │   ├── FedDesignCapacity
+│   │   │   └── 0
+│   │   ├── FedDualRolePower
+│   │   │   └── 0
+│   │   ├── FedExternalConnected
+│   │   │   └── 0
+│   │   ├── FedPdSpecRevision
+│   │   │   └── 0
+│   │   ├── FedPortPowerRole
+│   │   │   └── 1
+│   │   ├── FedProductID
+│   │   │   └── 0
+│   │   ├── FedPwrPolicySt
+│   │   │   └── 0
+│   │   ├── FedRemainingCapacity
+│   │   │   └── 0
+│   │   ├── FedSnkConfReason
+│   │   │   └── 0
+│   │   ├── FedSrcConfReason
+│   │   │   └── 0
+│   │   ├── FedStateOfCharge
+│   │   │   └── 0
+│   │   └── FedVendorID
+│   │       └── 0
+│   ├── .
+│   │   ├── FedDesignCapacity
+│   │   │   └── 0
+│   │   ├── FedDualRolePower
+│   │   │   └── 1
+│   │   ├── FedExternalConnected
+│   │   │   └── 1
+│   │   ├── FedPdSpecRevision
+│   │   │   └── 2
+│   │   ├── FedPortPowerRole
+│   │   │   └── 0
+│   │   ├── FedProductID
+│   │   │   └── 49193
+│   │   ├── FedPwrPolicySt
+│   │   │   └── 0
+│   │   ├── FedRemainingCapacity
+│   │   │   └── 0
+│   │   ├── FedSnkConfReason
+│   │   │   └── 0
+│   │   ├── FedSrcConfReason
+│   │   │   └── 0
+│   │   ├── FedStateOfCharge
+│   │   │   └── 0
+│   │   └── FedVendorID
+│   │       └── 16700
+│   └── .
+│       ├── FedDesignCapacity
+│       │   └── 0
+│       ├── FedDualRolePower
+│       │   └── 0
+│       ├── FedExternalConnected
+│       │   └── 1
+│       ├── FedPdSpecRevision
+│       │   └── 0
+│       ├── FedPortPowerRole
+│       │   └── 0
+│       ├── FedProductID
+│       │   └── 0
+│       ├── FedPwrPolicySt
+│       │   └── 0
+│       ├── FedRemainingCapacity
+│       │   └── 0
+│       ├── FedSnkConfReason
+│       │   └── 0
+│       ├── FedSrcConfReason
+│       │   └── 0
+│       ├── FedStateOfCharge
+│       │   └── 0
+│       └── FedVendorID
+│           └── 0
+├── FullPathUpdated
+│   └── 1785300994
+├── FullyCharged
+│   └── 1
+├── GasGaugeFirmwareVersion
+│   └── 2
+├── IOGeneralInterest
+│   └── IOCommand is not serializable
+├── IOReportLegend
+│   └── .
+│       ├── IOReportChannelInfo
+│       │   └── IOReportChannelUnit
+│       │       └── 0
+│       ├── IOReportChannels
+│       │   └── .
+│       │       ├── 7167869599145487988
+│       │       ├── 6460407809
+│       │       └── BatteryCycleCount
+│       └── IOReportGroupName
+│           └── Battery
+├── IOReportLegendPublic
+│   └── 1
+├── InstantAmperage
+│   └── 0
+├── IsCharging
+│   └── 0
+├── Location
+│   └── 0
+├── ManufacturerData
+│   └── {length = 32, bytes = 0x00000000 0b000100 271d0000 04333531 ... 4c000000 00000000 }
+├── MaxCapacity
+│   └── 100
+├── NominalChargeCapacity
+│   └── 5949
+├── PackReserve
+│   └── 152
+├── PermanentFailureStatus
+│   └── 0
+├── PortControllerInfo
+│   ├── .
+│   │   ├── PortControllerActiveContractRdo
+│   │   │   └── 0
+│   │   ├── PortControllerAttachCount
+│   │   │   └── 6
+│   │   ├── PortControllerBootFlags
+│   │   │   └── 0
+│   │   ├── PortControllerCapMismatch
+│   │   │   └── 1
+│   │   ├── PortControllerDataRoleSwapCount
+│   │   │   └── 0
+│   │   ├── PortControllerDataRoleSwapFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerDetachCount
+│   │   │   └── 5
+│   │   ├── PortControllerDnSt
+│   │   │   └── 115
+│   │   ├── PortControllerElectionFailReason
+│   │   │   └── 0
+│   │   ├── PortControllerEvtBuffer
+│   │   │   └── {length = 120, bytes = 0x06060606 06060606 06060606 06060606 ... 5f5f4001 485e015f }
+│   │   ├── PortControllerFetStatus
+│   │   │   └── 130
+│   │   ├── PortControllerFwVersion
+│   │   │   └── 3178752
+│   │   ├── PortControllerHardResetCount
+│   │   │   └── 0
+│   │   ├── PortControllerHvEnRecoveryCount
+│   │   │   └── 0
+│   │   ├── PortControllerI2cErrCount
+│   │   │   └── 0
+│   │   ├── PortControllerInpFetEnFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntAlert
+│   │   │   └── 101
+│   │   ├── PortControllerIrqCntAppLd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntConSrc
+│   │   │   └── 7
+│   │   ├── PortControllerIrqCntHrdRst
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPdStsUpd
+│   │   │   └── 13
+│   │   ├── PortControllerIrqCntPlg
+│   │   │   └── 11
+│   │   ├── PortControllerIrqCntPwrStsUpd
+│   │   │   └── 19
+│   │   ├── PortControllerIrqCntRxIdSop
+│   │   │   └── 6
+│   │   ├── PortControllerIrqCntRxRdo
+│   │   │   └── 7
+│   │   ├── PortControllerIrqCntRxSnkCap
+│   │   │   └── 6
+│   │   ├── PortControllerIrqCntRxSrcCap
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntStsUpd
+│   │   │   └── 63
+│   │   ├── PortControllerIrqCntUsb2Plg
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUsb2Wak
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUvdmEnum
+│   │   │   └── 2
+│   │   ├── PortControllerIrqCntUvdmStsUpd
+│   │   │   └── 19
+│   │   ├── PortControllerIrqCntWakeAck
+│   │   │   └── 53184
+│   │   ├── PortControllerIrqCntldcm
+│   │   │   └── 0
+│   │   ├── PortControllerLoserReason
+│   │   │   └── 1
+│   │   ├── PortControllerMaxPower
+│   │   │   └── 0
+│   │   ├── PortControllerNEprPDOs
+│   │   │   └── 0
+│   │   ├── PortControllerNPDOs
+│   │   │   └── 0
+│   │   ├── PortControllerPDst
+│   │   │   └── 0
+│   │   ├── PortControllerPortMode
+│   │   │   └── 2
+│   │   ├── PortControllerPortPDO
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   └── 0
+│   │   ├── PortControllerPowerState
+│   │   │   └── 255
+│   │   ├── PortControllerPwrRoleSwapCount
+│   │   │   └── 0
+│   │   ├── PortControllerPwrRoleSwapFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerShortDetectCount
+│   │   │   └── 0
+│   │   ├── PortControllerSleepCmdFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerSlpWakDisCause
+│   │   │   └── 0
+│   │   ├── PortControllerSlpWakDisTime
+│   │   │   └── 0
+│   │   ├── PortControllerSlpWakIsSleepEnabled
+│   │   │   └── 1
+│   │   ├── PortControllerSrcTypes
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoRejectCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoRetryCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdyCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdyRejectCount
+│   │   │   └── 0
+│   │   ├── PortControllerStuckCmdCount
+│   │   │   └── 0
+│   │   ├── PortControllerSurpriseAckCount
+│   │   │   └── 0
+│   │   ├── PortControllerSurpriseNackCount
+│   │   │   └── 0
+│   │   ├── PortControllerUvdmStatus
+│   │   │   └── 2
+│   │   ├── PortControllerVdoFailCount
+│   │   │   └── 10
+│   │   ├── PortControllerWakeCmdFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerWakeFailCount
+│   │   │   └── 0
+│   │   └── PortControllerWakeTimeoutCount
+│   │       └── 0
+│   ├── .
+│   │   ├── PortControllerActiveContractRdo
+│   │   │   └── 0
+│   │   ├── PortControllerAttachCount
+│   │   │   └── 2
+│   │   ├── PortControllerBootFlags
+│   │   │   └── 0
+│   │   ├── PortControllerCapMismatch
+│   │   │   └── 0
+│   │   ├── PortControllerDataRoleSwapCount
+│   │   │   └── 0
+│   │   ├── PortControllerDataRoleSwapFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerDetachCount
+│   │   │   └── 1
+│   │   ├── PortControllerDnSt
+│   │   │   └── 115
+│   │   ├── PortControllerElectionFailReason
+│   │   │   └── 0
+│   │   ├── PortControllerEvtBuffer
+│   │   │   └── {length = 120, bytes = 0x00000000 00000000 00000000 00000000 ... 0003011a 035ff800 }
+│   │   ├── PortControllerFetStatus
+│   │   │   └── 2
+│   │   ├── PortControllerFwVersion
+│   │   │   └── 3178752
+│   │   ├── PortControllerHardResetCount
+│   │   │   └── 0
+│   │   ├── PortControllerHvEnRecoveryCount
+│   │   │   └── 0
+│   │   ├── PortControllerI2cErrCount
+│   │   │   └── 0
+│   │   ├── PortControllerInpFetEnFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntAlert
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntAppLd
+│   │   │   └── 1
+│   │   ├── PortControllerIrqCntConSrc
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntHrdRst
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPdStsUpd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPlg
+│   │   │   └── 3
+│   │   ├── PortControllerIrqCntPwrStsUpd
+│   │   │   └── 5
+│   │   ├── PortControllerIrqCntRxIdSop
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxRdo
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxSnkCap
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxSrcCap
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntStsUpd
+│   │   │   └── 181
+│   │   ├── PortControllerIrqCntUsb2Plg
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUsb2Wak
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUvdmEnum
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUvdmStsUpd
+│   │   │   └── 3
+│   │   ├── PortControllerIrqCntWakeAck
+│   │   │   └── 53183
+│   │   ├── PortControllerIrqCntldcm
+│   │   │   └── 0
+│   │   ├── PortControllerLoserReason
+│   │   │   └── 1
+│   │   ├── PortControllerMaxPower
+│   │   │   └── 0
+│   │   ├── PortControllerNEprPDOs
+│   │   │   └── 0
+│   │   ├── PortControllerNPDOs
+│   │   │   └── 0
+│   │   ├── PortControllerPDst
+│   │   │   └── 0
+│   │   ├── PortControllerPortMode
+│   │   │   └── 2
+│   │   ├── PortControllerPortPDO
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   └── 0
+│   │   ├── PortControllerPowerState
+│   │   │   └── 255
+│   │   ├── PortControllerPwrRoleSwapCount
+│   │   │   └── 0
+│   │   ├── PortControllerPwrRoleSwapFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerShortDetectCount
+│   │   │   └── 0
+│   │   ├── PortControllerSleepCmdFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerSlpWakDisCause
+│   │   │   └── 0
+│   │   ├── PortControllerSlpWakDisTime
+│   │   │   └── 0
+│   │   ├── PortControllerSlpWakIsSleepEnabled
+│   │   │   └── 1
+│   │   ├── PortControllerSrcTypes
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoRejectCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoRetryCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdyCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdyRejectCount
+│   │   │   └── 0
+│   │   ├── PortControllerStuckCmdCount
+│   │   │   └── 0
+│   │   ├── PortControllerSurpriseAckCount
+│   │   │   └── 0
+│   │   ├── PortControllerSurpriseNackCount
+│   │   │   └── 0
+│   │   ├── PortControllerUvdmStatus
+│   │   │   └── 0
+│   │   ├── PortControllerVdoFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerWakeCmdFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerWakeFailCount
+│   │   │   └── 0
+│   │   └── PortControllerWakeTimeoutCount
+│   │       └── 0
+│   ├── .
+│   │   ├── PortControllerActiveContractRdo
+│   │   │   └── 1132923330
+│   │   ├── PortControllerAttachCount
+│   │   │   └── 1
+│   │   ├── PortControllerBootFlags
+│   │   │   └── 0
+│   │   ├── PortControllerCapMismatch
+│   │   │   └── 0
+│   │   ├── PortControllerDataRoleSwapCount
+│   │   │   └── 0
+│   │   ├── PortControllerDataRoleSwapFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerDetachCount
+│   │   │   └── 1
+│   │   ├── PortControllerDnSt
+│   │   │   └── 83
+│   │   ├── PortControllerElectionFailReason
+│   │   │   └── 0
+│   │   ├── PortControllerEvtBuffer
+│   │   │   └── {length = 120, bytes = 0x00000000 00000000 00000000 00000000 ... 485e005f 40015e00 }
+│   │   ├── PortControllerFetStatus
+│   │   │   └── 140
+│   │   ├── PortControllerFwVersion
+│   │   │   └── 3178752
+│   │   ├── PortControllerHardResetCount
+│   │   │   └── 0
+│   │   ├── PortControllerHvEnRecoveryCount
+│   │   │   └── 0
+│   │   ├── PortControllerI2cErrCount
+│   │   │   └── 0
+│   │   ├── PortControllerInpFetEnFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntAlert
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntAppLd
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntConSrc
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntHrdRst
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntPdStsUpd
+│   │   │   └── 5
+│   │   ├── PortControllerIrqCntPlg
+│   │   │   └── 2
+│   │   ├── PortControllerIrqCntPwrStsUpd
+│   │   │   └── 4
+│   │   ├── PortControllerIrqCntRxIdSop
+│   │   │   └── 2
+│   │   ├── PortControllerIrqCntRxRdo
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntRxSnkCap
+│   │   │   └── 1
+│   │   ├── PortControllerIrqCntRxSrcCap
+│   │   │   └── 1
+│   │   ├── PortControllerIrqCntStsUpd
+│   │   │   └── 101
+│   │   ├── PortControllerIrqCntUsb2Plg
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUsb2Wak
+│   │   │   └── 0
+│   │   ├── PortControllerIrqCntUvdmEnum
+│   │   │   └── 5
+│   │   ├── PortControllerIrqCntUvdmStsUpd
+│   │   │   └── 6
+│   │   ├── PortControllerIrqCntWakeAck
+│   │   │   └── 53184
+│   │   ├── PortControllerIrqCntldcm
+│   │   │   └── 0
+│   │   ├── PortControllerLoserReason
+│   │   │   └── 0
+│   │   ├── PortControllerMaxPower
+│   │   │   └── 90000
+│   │   ├── PortControllerNEprPDOs
+│   │   │   └── 0
+│   │   ├── PortControllerNPDOs
+│   │   │   └── 4
+│   │   ├── PortControllerPDst
+│   │   │   └── 5
+│   │   ├── PortControllerPortMode
+│   │   │   └── 2
+│   │   ├── PortControllerPortPDO
+│   │   │   ├── 771854636
+│   │   │   ├── 3330348
+│   │   │   ├── 3453228
+│   │   │   ├── 3555778
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   ├── 0
+│   │   │   └── 0
+│   │   ├── PortControllerPowerState
+│   │   │   └── 255
+│   │   ├── PortControllerPwrRoleSwapCount
+│   │   │   └── 0
+│   │   ├── PortControllerPwrRoleSwapFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerShortDetectCount
+│   │   │   └── 0
+│   │   ├── PortControllerSleepCmdFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerSlpWakDisCause
+│   │   │   └── 0
+│   │   ├── PortControllerSlpWakDisTime
+│   │   │   └── 0
+│   │   ├── PortControllerSlpWakIsSleepEnabled
+│   │   │   └── 1
+│   │   ├── PortControllerSrcTypes
+│   │   │   └── 7
+│   │   ├── PortControllerSrdoCount
+│   │   │   └── 2
+│   │   ├── PortControllerSrdoRejectCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdoRetryCount
+│   │   │   └── 0
+│   │   ├── PortControllerSrdyCount
+│   │   │   └── 3
+│   │   ├── PortControllerSrdyRejectCount
+│   │   │   └── 0
+│   │   ├── PortControllerStuckCmdCount
+│   │   │   └── 0
+│   │   ├── PortControllerSurpriseAckCount
+│   │   │   └── 0
+│   │   ├── PortControllerSurpriseNackCount
+│   │   │   └── 0
+│   │   ├── PortControllerUvdmStatus
+│   │   │   └── 0
+│   │   ├── PortControllerVdoFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerWakeCmdFailCount
+│   │   │   └── 0
+│   │   ├── PortControllerWakeFailCount
+│   │   │   └── 0
+│   │   └── PortControllerWakeTimeoutCount
+│   │       └── 0
+│   └── .
+│       ├── PortControllerActiveContractRdo
+│       │   └── 1166363987
+│       ├── PortControllerAttachCount
+│       │   └── 1
+│       ├── PortControllerBootFlags
+│       │   └── 0
+│       ├── PortControllerCapMismatch
+│       │   └── 0
+│       ├── PortControllerDataRoleSwapCount
+│       │   └── 0
+│       ├── PortControllerDataRoleSwapFailCount
+│       │   └── 0
+│       ├── PortControllerDetachCount
+│       │   └── 1
+│       ├── PortControllerDnSt
+│       │   └── 0
+│       ├── PortControllerElectionFailReason
+│       │   └── 0
+│       ├── PortControllerEvtBuffer
+│       │   └── {length = 120, bytes = 0x00000000 00000000 00000000 00000000 ... 023f025f f023f01b }
+│       ├── PortControllerFetStatus
+│       │   └── 0
+│       ├── PortControllerFwVersion
+│       │   └── 3178752
+│       ├── PortControllerHardResetCount
+│       │   └── 0
+│       ├── PortControllerHvEnRecoveryCount
+│       │   └── 0
+│       ├── PortControllerI2cErrCount
+│       │   └── 0
+│       ├── PortControllerInpFetEnFailCount
+│       │   └── 0
+│       ├── PortControllerIrqCntAlert
+│       │   └── 0
+│       ├── PortControllerIrqCntAppLd
+│       │   └── 0
+│       ├── PortControllerIrqCntConSrc
+│       │   └── 0
+│       ├── PortControllerIrqCntHrdRst
+│       │   └── 0
+│       ├── PortControllerIrqCntPdStsUpd
+│       │   └── 2
+│       ├── PortControllerIrqCntPlg
+│       │   └── 3
+│       ├── PortControllerIrqCntPwrStsUpd
+│       │   └── 4
+│       ├── PortControllerIrqCntRxIdSop
+│       │   └── 2
+│       ├── PortControllerIrqCntRxRdo
+│       │   └── 0
+│       ├── PortControllerIrqCntRxSnkCap
+│       │   └── 0
+│       ├── PortControllerIrqCntRxSrcCap
+│       │   └── 1
+│       ├── PortControllerIrqCntStsUpd
+│       │   └── 6
+│       ├── PortControllerIrqCntUsb2Plg
+│       │   └── 0
+│       ├── PortControllerIrqCntUsb2Wak
+│       │   └── 0
+│       ├── PortControllerIrqCntUvdmEnum
+│       │   └── 1
+│       ├── PortControllerIrqCntUvdmStsUpd
+│       │   └── 6
+│       ├── PortControllerIrqCntWakeAck
+│       │   └── 53184
+│       ├── PortControllerIrqCntldcm
+│       │   └── 0
+│       ├── PortControllerLoserReason
+│       │   └── 1
+│       ├── PortControllerMaxPower
+│       │   └── 0
+│       ├── PortControllerNEprPDOs
+│       │   └── 0
+│       ├── PortControllerNPDOs
+│       │   └── 4
+│       ├── PortControllerPDst
+│       │   └── 0
+│       ├── PortControllerPortMode
+│       │   └── 2
+│       ├── PortControllerPortPDO
+│       │   ├── 134320424
+│       │   ├── 184618
+│       │   ├── 307499
+│       │   ├── 409939
+│       │   ├── 0
+│       │   ├── 0
+│       │   ├── 0
+│       │   ├── 0
+│       │   ├── 0
+│       │   ├── 0
+│       │   ├── 0
+│       │   ├── 0
+│       │   └── 0
+│       ├── PortControllerPowerState
+│       │   └── 255
+│       ├── PortControllerPwrRoleSwapCount
+│       │   └── 0
+│       ├── PortControllerPwrRoleSwapFailCount
+│       │   └── 0
+│       ├── PortControllerShortDetectCount
+│       │   └── 0
+│       ├── PortControllerSleepCmdFailCount
+│       │   └── 0
+│       ├── PortControllerSlpWakDisCause
+│       │   └── 0
+│       ├── PortControllerSlpWakDisTime
+│       │   └── 0
+│       ├── PortControllerSlpWakIsSleepEnabled
+│       │   └── 1
+│       ├── PortControllerSrcTypes
+│       │   └── 0
+│       ├── PortControllerSrdoCount
+│       │   └── 1
+│       ├── PortControllerSrdoRejectCount
+│       │   └── 0
+│       ├── PortControllerSrdoRetryCount
+│       │   └── 0
+│       ├── PortControllerSrdyCount
+│       │   └── 2
+│       ├── PortControllerSrdyRejectCount
+│       │   └── 1
+│       ├── PortControllerStuckCmdCount
+│       │   └── 0
+│       ├── PortControllerSurpriseAckCount
+│       │   └── 0
+│       ├── PortControllerSurpriseNackCount
+│       │   └── 0
+│       ├── PortControllerUvdmStatus
+│       │   └── 0
+│       ├── PortControllerVdoFailCount
+│       │   └── 0
+│       ├── PortControllerWakeCmdFailCount
+│       │   └── 0
+│       ├── PortControllerWakeFailCount
+│       │   └── 0
+│       └── PortControllerWakeTimeoutCount
+│           └── 0
+├── PostChargeWaitSeconds
+│   └── 120
+├── PostDischargeWaitSeconds
+│   └── 120
+├── PowerOutDetails
+│   ├── .
+│   │   ├── AccumulatedPower
+│   │   │   └── 9461615
+│   │   ├── AccumulatorCount
+│   │   │   └── 17620
+│   │   ├── AccumulatorErrorCount
+│   │   │   └── 0
+│   │   ├── AdapterVoltage
+│   │   │   └── 5241
+│   │   ├── ConfiguredCurrent
+│   │   │   └── 3000
+│   │   ├── ConfiguredVoltage
+│   │   │   └── 5000
+│   │   ├── Current
+│   │   │   └── 91
+│   │   ├── FilteredPower
+│   │   │   └── 546
+│   │   ├── NumLDCMCollisions
+│   │   │   └── 0
+│   │   ├── PDPowermW
+│   │   │   └── 15000
+│   │   ├── PortIndex
+│   │   │   └── 1
+│   │   ├── PortType
+│   │   │   └── 0
+│   │   ├── PowerState
+│   │   │   └── 0
+│   │   ├── USBSleepPoolPowermW
+│   │   │   └── 12000
+│   │   ├── USBWakePoolPowermW
+│   │   │   └── 12000
+│   │   ├── VConnAccumulatedPower
+│   │   │   └── 850141
+│   │   ├── VConnAccumulatorCount
+│   │   │   └── 17620
+│   │   ├── VConnAccumulatorErrorCount
+│   │   │   └── 0
+│   │   ├── VConnCurrent
+│   │   │   └── 9
+│   │   ├── VConnMaxCurrent
+│   │   │   └── 330
+│   │   ├── VConnPower
+│   │   │   └── 49
+│   │   └── Watts
+│   │       └── 480
+│   └── .
+│       ├── AccumulatedPower
+│       │   └── 842391
+│       ├── AccumulatorCount
+│       │   └── 3107
+│       ├── AccumulatorErrorCount
+│       │   └── 0
+│       ├── AdapterVoltage
+│       │   └── 5225
+│       ├── ConfiguredCurrent
+│       │   └── 3000
+│       ├── ConfiguredVoltage
+│       │   └── 5000
+│       ├── Current
+│       │   └── 51
+│       ├── FilteredPower
+│       │   └── 266
+│       ├── NumLDCMCollisions
+│       │   └── 0
+│       ├── PDPowermW
+│       │   └── 0
+│       ├── PortIndex
+│       │   └── 2
+│       ├── PortType
+│       │   └── 0
+│       ├── PowerState
+│       │   └── 0
+│       ├── USBSleepPoolPowermW
+│       │   └── 0
+│       ├── USBWakePoolPowermW
+│       │   └── 0
+│       ├── VConnAccumulatedPower
+│       │   └── 20419
+│       ├── VConnAccumulatorCount
+│       │   └── 3107
+│       ├── VConnAccumulatorErrorCount
+│       │   └── 0
+│       ├── VConnCurrent
+│       │   └── 1
+│       ├── VConnMaxCurrent
+│       │   └── 330
+│       ├── VConnPower
+│       │   └── 7
+│       └── Watts
+│           └── 267
+├── PowerTelemetryData
+│   ├── AccumulatedAdapterEfficiencyLoss
+│   │   └── 7567410041024794
+│   ├── AccumulatedBatteryDischarge
+│   │   └── -306495591
+│   ├── AccumulatedBatteryPower
+│   │   └── 56087758
+│   ├── AccumulatedSystemEnergyConsumed
+│   │   └── 1647270914130
+│   ├── AccumulatedSystemLoad
+│   │   └── 7669063644
+│   ├── AccumulatedSystemPowerIn
+│   │   └── 5930178556995
+│   ├── AccumulatedWallEnergyEstimate
+│   │   └── 1848050920
+│   ├── AdapterEfficiencyLoss
+│   │   └── 206
+│   ├── AdapterEfficiencyLossAccumulatorCount
+│   │   └── 1931226
+│   ├── BatteryDischargeAccumulatorCount
+│   │   └── 48906
+│   ├── BatteryPower
+│   │   └── 0
+│   ├── BatteryPowerAccumulatorCount
+│   │   └── 4441
+│   ├── PowerTelemetryErrorCount
+│   │   └── 0
+│   ├── SystemCurrentIn
+│   │   └── 681
+│   ├── SystemEnergyConsumed
+│   │   └── 3691
+│   ├── SystemLoad
+│   │   └── 13291
+│   ├── SystemLoadAccumulatorCount
+│   │   └── 2050681
+│   ├── SystemPowerIn
+│   │   └── 13291
+│   ├── SystemPowerInAccumulatorCount
+│   │   └── 1933681
+│   ├── SystemVoltageIn
+│   │   └── 19529
+│   └── WallEnergyEstimate
+│       └── 3897
+├── Serial
+│   └── F8YHB6006DC0000FWK
+├── SkipperNEIgnoreAtCritical
+│   └── 0
+├── Temperature
+│   └── 3053
+├── TimeRemaining
+│   └── 65535
+├── UpdateTime
+│   └── 1785301354
+├── UserVisiblePathUpdated
+│   └── 1785301354
+├── VirtualTemperature
+│   └── 3209
+├── Voltage
+│   └── 12817
+└── built-in
+    └── 1

--- a/MeasuredValues/AppleSmartBattery/Mac_mini_M4_macOS_26.txt
+++ b/MeasuredValues/AppleSmartBattery/Mac_mini_M4_macOS_26.txt
@@ -1,0 +1,62 @@
+.
+├── AdapterDetails
+│   └── FamilyCode
+│       └── 0
+├── AdapterInfo
+│   └── 0
+├── Amperage
+│   └── 0
+├── AppleRawAdapterDetails
+│   └── empty
+├── BatteryInstalled
+│   └── 0
+├── BatteryInvalidWakeSeconds
+│   └── 30
+├── BestAdapterIndex
+│   └── 0
+├── BootPathUpdated
+│   └── 1783775591
+├── CurrentCapacity
+│   └── 0
+├── CycleCount
+│   └── 0
+├── ExternalChargeCapable
+│   └── 1
+├── ExternalConnected
+│   └── 1
+├── FullPathUpdated
+│   └── 1785307963
+├── IOGeneralInterest
+│   └── IOCommand is not serializable
+├── IOReportLegend
+│   └── .
+│       ├── IOReportChannelInfo
+│       │   └── IOReportChannelUnit
+│       │       └── 0
+│       ├── IOReportChannels
+│       │   └── .
+│       │       ├── 7167869599145487988
+│       │       ├── 6460407809
+│       │       └── BatteryCycleCount
+│       └── IOReportGroupName
+│           └── Battery
+├── IOReportLegendPublic
+│   └── 1
+├── IsCharging
+│   └── 0
+├── Location
+│   └── 0
+├── MaxCapacity
+│   └── 0
+├── PostChargeWaitSeconds
+│   └── 120
+├── PostDischargeWaitSeconds
+│   └── 120
+├── TimeRemaining
+│   └── 0
+├── UpdateTime
+│   └── 1785307963
+├── Voltage
+│   └── 0
+└── built-in
+    └── 1

--- a/MeasuredValues/AppleSmartBatteryPack/MacBook_Air_M2_macOS_27.txt
+++ b/MeasuredValues/AppleSmartBatteryPack/MacBook_Air_M2_macOS_27.txt
@@ -1,0 +1,159 @@
+.
+├── BankCount
+│   └── 3
+├── BatteryData
+│   ├── AbsoluteCapacity
+│   │   └── 0
+│   ├── Amperage
+│   │   └── 2037
+│   ├── AppleRawBatteryVoltage
+│   │   └── 11866
+│   ├── AppleRawCurrentCapacity
+│   │   └── 1594
+│   ├── AppleRawMaxCapacity
+│   │   └── 4427
+│   ├── BatteryCellDisconnectCount
+│   │   └── 0
+│   ├── BatteryHealthMetric
+│   │   └── 0
+│   ├── BatteryPfCommsFailure
+│   │   └── 0
+│   ├── BatteryPower
+│   │   └── 0
+│   ├── BatteryState
+│   │   └── {length = 17, bytes = 0x00000000000000000087e4400243030010}
+│   ├── ChargeAccum
+│   │   └── 0
+│   ├── ChemID
+│   │   └── 21353
+│   ├── CurrentCapacity
+│   │   └── 37
+│   ├── CycleCount
+│   │   └── 37
+│   ├── DailyMaxSoc
+│   │   └── 33
+│   ├── DailyMinSoc
+│   │   └── 26
+│   ├── DataFlashWriteCount
+│   │   └── 13197
+│   ├── DateOfFirstUse
+│   │   └── 0
+│   ├── DesignCapacity
+│   │   └── 4563
+│   ├── Dod0AtQualifiedQmax
+│   │   └── 0
+│   ├── FaultType
+│   │   └── 1
+│   ├── FccComp1
+│   │   └── 4427
+│   ├── FccComp2
+│   │   └── 4427
+│   ├── FilteredCurrent
+│   │   └── 0
+│   ├── Flags
+│   │   └── 16777216
+│   ├── FullyCharged
+│   │   └── 0
+│   ├── GasGaugeFirmwareVersion
+│   │   └── 2
+│   ├── GaugeFlagRaw
+│   │   └── 128
+│   ├── IPDBatteryDemand
+│   │   └── 21065
+│   ├── ISS
+│   │   └── 2016
+│   ├── ITMiscStatus
+│   │   └── 0
+│   ├── IdealCRate
+│   │   └── 1.2
+│   ├── InstantAmperage
+│   │   └── 2037
+│   ├── LifetimeData
+│   │   ├── AverageTemperature
+│   │   │   └── 268
+│   │   ├── CycleCountLastQmax
+│   │   │   └── 35
+│   │   ├── MaximumChargeCurrent
+│   │   │   └── 5071
+│   │   ├── MaximumDischargeCurrent
+│   │   │   └── -2915
+│   │   ├── MaximumPackVoltage
+│   │   │   └── 13310
+│   │   ├── MaximumTemperature
+│   │   │   └── 38
+│   │   ├── MinimumPackVoltage
+│   │   │   └── 9008
+│   │   ├── MinimumTemperature
+│   │   │   └── 13
+│   │   ├── RDISCnt
+│   │   │   └── 0
+│   │   ├── Raw
+│   │   │   └── {length = 64, bytes = 0x073be112 00003eb7 00000000 00000000 ... 010c0008 3b490022 }
+│   │   ├── TemperatureSamples
+│   │   │   └── 539465
+│   │   ├── TotalOperatingTime
+│   │   │   └── 33716
+│   │   └── UpdateTime
+│   │       └── 1785305085
+│   ├── ManufactureDate
+│   │   └── 56282177351731
+│   ├── MaxCapacity
+│   │   └── 100
+│   ├── MfgData
+│   │   └── {length = 32, bytes = 0x00000000 0b000100 f9140000 04323231 ... 4c002800 00000000 }
+│   ├── MiscStatus
+│   │   └── 64
+│   ├── NominalChargeCapacity
+│   │   └── 4554
+│   ├── PackCurrentAccumulator
+│   │   └── 1607032
+│   ├── PackCurrentAccumulatorCount
+│   │   └── 945
+│   ├── PackReserve
+│   │   └── 127
+│   ├── PassedCharge
+│   │   └── 720
+│   ├── PermanentFailureStatus
+│   │   └── 0
+│   ├── QmaxDisqualificationReason
+│   │   └── 0
+│   ├── Qstart
+│   │   └── 0
+│   ├── RSS
+│   │   └── 0
+│   ├── ResScale
+│   │   └── 0
+│   ├── Serial
+│   │   └── F8Y2275059S10X2AF
+│   ├── SimRate
+│   │   └── 0
+│   ├── Soc1Voltage
+│   │   └── 0
+│   ├── StateOfCharge
+│   │   └── 36
+│   ├── Temperature
+│   │   └── 3359
+│   ├── TrueRemainingCapacity
+│   │   └── 0
+│   ├── VacVoltageLimit
+│   │   └── 4435
+│   ├── VirtualTemperature
+│   │   └── 3359
+│   ├── VmaxNcc
+│   │   └── 4435
+│   ├── Voltage
+│   │   └── 11866
+│   └── iMaxAndSocSmoothTable
+│       └── {length = 32, bytes = 0x00000000 00000000 00000000 00000000 ... 00000000 00000000 }
+├── CarrierMode
+│   ├── CarrierModeHighVoltage
+│   │   └── 0
+│   ├── CarrierModeLowVoltage
+│   │   └── 0
+│   └── CarrierModeStatus
+│       └── 0
+├── ID
+│   └── 0
+├── KioskMode
+└── Serial
+    └── F8Y2275059S10X2AF


### PR DESCRIPTION
I am going to accumulate real-world measurement data from AppleSmartBattery so that I can provide the features with confidence.

I use the following code to retrieve the data.

- [SwiftTree](https://gist.github.com/Kyome22/7d1dd240fe0505a4521dd398116a0b20)
- [SmartBattery](https://gist.github.com/Kyome22/b6223c8646a3a3c959f61dd732f042bb)