### PR TITLE
Fix maximum capacity on macOS 27 and make the battery test OS independent

### DIFF
--- a/Sources/SystemInfoKit/Repositories/BatteryRepository.swift
+++ b/Sources/SystemInfoKit/Repositories/BatteryRepository.swift
@@ -41,12 +41,14 @@ struct BatteryRepository: SystemRepository {
         }
 
         if #available(macOS 27.0, *) {
-            if let batteryData = batteryDict["BatteryData"] as? [String: AnyObject],
-               let currentCapacity = batteryData["CurrentCapacity"] as? Double,
-               let maxCapacity = batteryData["MaxCapacity"] as? Double
-            {
-                result.percentage = .init(rawValue: currentCapacity / 100, width: 5, language: language)
-                result.maxCapacity = .init(rawValue: maxCapacity / 100, width: 5, language: language)
+            if let batteryData = batteryDict["BatteryData"] as? [String: AnyObject] {
+                if let currentCapacity = batteryData["CurrentCapacity"] as? Double {
+                    result.percentage = .init(rawValue: currentCapacity / 100, width: 5, language: language)
+                }
+                if let fullChargeCapacity = batteryData["FullChargeCapacity"] as? Double,
+                   let designCapacity = batteryData["DesignCapacity"] as? Double {
+                    result.maxCapacity = .init(rawValue: min(fullChargeCapacity / designCapacity, 1), width: 5, language: language)
+                }
             }
             if let batteryPackDict = fetchIOServiceProperties(name: "AppleSmartBatteryPack"),
                 let batteryData = batteryPackDict["BatteryData"] as? [String: AnyObject],

--- a/Tests/SystemInfoKitTests/RepositoryTests/BatteryRepositoryTests.swift
+++ b/Tests/SystemInfoKitTests/RepositoryTests/BatteryRepositoryTests.swift
@@ -24,6 +24,12 @@ struct BatteryRepositoryTests {
                             "AdapterDetails" : NSDictionary(dictionary: ["Name" : "SomeAdapter"]),
                             "CycleCount" : NSNumber(integerLiteral: 7),
                             "Temperature" : NSNumber(integerLiteral: 3019),
+                            "BatteryData" : NSDictionary(dictionary: [
+                                "CurrentCapacity" : NSNumber(value: 98.2),
+                                "FullChargeCapacity" : NSNumber(integerLiteral: 5982),
+                                "DesignCapacity" : NSNumber(integerLiteral: 6249),
+                                "Temperature" : NSNumber(integerLiteral: 3019),
+                            ]),
                         ])
                         pointer?.pointee = Unmanaged.passRetained(dict)
                         return kIOReturnSuccess


### PR DESCRIPTION
Checked `BatteryRepository` against the samples in `MeasuredValues/` before cutting a release. Three of the four devices are fine; the macOS 27 path reports the wrong maximum capacity.

| device / OS | branch | percentage | maximum capacity | temperature |
| --- | --- | --- | --- | --- |
| MacBook Pro M1 Pro / 15 | ≤26 | 59/100 = 59.0% ✅ | 5704/6075 = 93.9% ✅ | 3115 → 31.2°C ✅ |
| MacBook Pro M4 Pro / 26 | ≤26 | 100/100 = 100% ✅ | 5797/6249 = 92.8% ✅ | 3053 → 30.5°C ✅ |
| Mac mini M4 / 26 | ≤26 | skipped, `BatteryInstalled = 0` ✅ | — | — |
| MacBook Air M2 / 27 | 27 | 34/100 = 34.0% ✅ | 100/100 = **100%** ❌ | pack 3359 → 33.6°C ✅ |

`BatteryData.MaxCapacity` is the top of the percentage scale, not a health figure — it reads `100` on every sample in `MeasuredValues`, so the reported maximum capacity was pinned at 100% regardless of wear.

The `≤26` branch derives it from `AppleRawMaxCapacity / DesignCapacity`. The macOS 27 equivalent is `BatteryData.FullChargeCapacity / BatteryData.DesignCapacity`, and the two sources agree: `AppleSmartBattery.BatteryData.FullChargeCapacity` is `4427` and `AppleSmartBatteryPack.BatteryData.AppleRawMaxCapacity` is also `4427`, against a `DesignCapacity` of `4563`. So the MacBook Air M2 should read **97.0%**, not 100%.

Also split the percentage and the maximum capacity into separate `if let`s. They were in one chain, so a missing capacity key would silently take the battery percentage down with it — the percentage is the primary reading and should not depend on a secondary one.

## What is not broken

- The `AppleSmartBatteryPack` lookup is genuinely required on macOS 27: `Temperature` does not appear anywhere in the macOS 27 `AppleSmartBattery` tree.
- `AdapterDetails.Name` is absent on the M4 Pro sample only because it was not charging, and `adapterName` is only read when `isCharging` is true.

## Tests

`update_with_battery` only supplied the macOS 26 keys, so it fails on a macOS 27 host — the macOS 27 branch would find no `BatteryData` and report zeros. It now supplies both key sets, chosen so that either branch produces the same description, which makes the suite OS independent.

`xcodebuild test -scheme SystemInfoKit -destination 'platform=macOS'` on macOS 26: 19 tests in 8 suites, all passing. Worth running once on the macOS 27 machine as well, since that is the branch this PR changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)